### PR TITLE
[codex] Fix timestamps auto-next playback

### DIFF
--- a/inspector/frontend/src/tabs/timestamps/components/TimestampsAudio.svelte
+++ b/inspector/frontend/src/tabs/timestamps/components/TimestampsAudio.svelte
@@ -27,6 +27,8 @@
     // ---- Component ref ----
     let _player: AudioPlayer;
     let _range: AudioRange | null = null;
+    let _suppressAutoPause = false;
+    let _suppressAutoPauseTimer: ReturnType<typeof setTimeout> | null = null;
 
     const dispatch = createEventDispatcher<{
         prev: void;
@@ -54,8 +56,12 @@
         if (!tsPort.source && url) {
             tsPort.setSource({ audioUrl: url, cbrSrc: url, reciter: null, vbr: false });
         }
-        await loadTimestampsAudio(tsPort, get(loadedVerse), atTime ?? 0, autoplay);
-        currentTime.set(tsPort.currentTimeMs() / 1000);
+        try {
+            await loadTimestampsAudio(tsPort, get(loadedVerse), atTime ?? 0, autoplay);
+            currentTime.set(tsPort.currentTimeMs() / 1000);
+        } finally {
+            if (autoplay) _finishAutoPauseSuppressionSoon();
+        }
     }
 
     // ---- AudioRange wiring ----
@@ -84,6 +90,7 @@
         // Safe against a stale-range re-attach because onPlay below gates on
         // autoAdvancing, and the loadedVerse reactive block re-attaches the
         // rAF once the new range/policy land.
+        _beginAutoPauseSuppression();
         tsPort.play();
         if (mode === 'next') dispatch('autoNext');
         else if (mode === 'random-any') dispatch('autoRandomAny');
@@ -93,6 +100,24 @@
     function _disposeRange(): void {
         _range?.dispose();
         _range = null;
+    }
+
+    function _beginAutoPauseSuppression(): void {
+        _suppressAutoPause = true;
+        if (_suppressAutoPauseTimer) clearTimeout(_suppressAutoPauseTimer);
+        _suppressAutoPauseTimer = setTimeout(() => {
+            _suppressAutoPause = false;
+            _suppressAutoPauseTimer = null;
+        }, 1500);
+    }
+
+    function _finishAutoPauseSuppressionSoon(): void {
+        if (!_suppressAutoPause) return;
+        if (_suppressAutoPauseTimer) clearTimeout(_suppressAutoPauseTimer);
+        _suppressAutoPauseTimer = setTimeout(() => {
+            _suppressAutoPause = false;
+            _suppressAutoPauseTimer = null;
+        }, 0);
     }
 
     function _ensureRangeForCurrentState(): AudioRange | null {
@@ -156,6 +181,13 @@
     }
 
     function onPause(): void {
+        // Auto-next uses an internal boundary pause before re-arming playback
+        // and swapping/seeking to the next verse. Browsers can deliver that
+        // pause event late; treating it as a user pause stops the next load.
+        if (_suppressAutoPause) {
+            if (tsPort.element) currentTime.set(tsPort.currentTimeMs() / 1000);
+            return;
+        }
         _range?.stop();
         if (tsPort.element) currentTime.set(tsPort.currentTimeMs() / 1000);
     }
@@ -183,6 +215,11 @@
             4: 'unsupported format',
         };
         console.error('Audio load error:', msgs[code] || `code ${code}`, audio.src);
+        _suppressAutoPause = false;
+        if (_suppressAutoPauseTimer) {
+            clearTimeout(_suppressAutoPauseTimer);
+            _suppressAutoPauseTimer = null;
+        }
         autoAdvancing.set(false);
         dispatch('error');
     }
@@ -197,6 +234,7 @@
     });
 
     onDestroy(() => {
+        if (_suppressAutoPauseTimer) clearTimeout(_suppressAutoPauseTimer);
         _disposeRange();
         tsAudioElement.set(null);
         tsPort.attachElement(null);


### PR DESCRIPTION
## Summary

Fixes the Timestamps tab auto-next path so the next verse keeps playing after automatic advancement.

## Root cause

Auto-next crosses the `AudioRange` boundary path, which intentionally pauses and flushes audio at the timestamp end before loading the next verse. A delayed native `pause` event from that internal boundary pause could be handled like a user pause after playback was re-armed, stopping the newly loaded verse. Manual next and random navigation skip that boundary pause path, so they continued to autoplay.

## Changes

- Suppress only internal auto-transition pause events during the auto-next handoff.
- Release suppression once the autoplay load settles, with a short timeout fallback.
- Clear the suppression timer on audio errors and component teardown.

## Validation

- `npm test -- src/tabs/timestamps src/lib/playback`
- `npm run check`