### PR TITLE
fix(inspector): store HF OAuth state server-side to fix iframe MismatchingStateError

### DIFF
--- a/inspector/app.py
+++ b/inspector/app.py
@@ -237,27 +237,18 @@ Compress(app)
 if os.environ.get("INSPECTOR_BEHIND_PROXY") == "1":
     app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
 
-# Flask's signed-cookie session is used by Authlib for the short-lived
-# OAuth state between /authorize and /callback. Our identity cookie is
-# separate (see services/auth.py). Both signed with the same secret.
+# Flask's secret key still signs anything that touches the session, but the
+# OAuth state no longer lives there — it's held server-side in a per-process
+# cache (see services/auth.py) because on HF Spaces the app runs in a
+# cross-site huggingface.co iframe where the third-party session cookie is
+# dropped by Safari, which surfaced as MismatchingStateError on the callback.
+# Our identity cookie is separate and signed with the same secret.
 try:
     app.secret_key = get_session_secret()
 except MissingSecret as e:
     # Local dev / test paths may not have the secret seeded. Anyone hitting
     # an OAuth route gets a 503 from auth_service.is_oauth_configured().
     logger.warning("INSPECTOR_SESSION_SECRET unavailable: %s", e)
-
-# HF Spaces renders the app inside an iframe under huggingface.co. The
-# OAuth round-trip (authorize → callback) is iframe-scoped, so the Flask
-# session cookie carrying the OAuth state must use SameSite=None;Secure
-# to survive the cross-site iframe navigation. Without these, Authlib
-# raises MismatchingStateError on the callback because the cookie never
-# came back. Locally the app runs over plain HTTP where SameSite=None
-# requires Secure (browsers reject otherwise), so fall back to Lax there.
-_behind_proxy = os.environ.get("INSPECTOR_BEHIND_PROXY") == "1"
-app.config["SESSION_COOKIE_SAMESITE"] = "None" if _behind_proxy else "Lax"
-app.config["SESSION_COOKIE_SECURE"] = _behind_proxy
-app.config["SESSION_COOKIE_HTTPONLY"] = True
 
 # Register the HF OAuth provider with Authlib so the auth routes can
 # resolve oauth.huggingface at request time.

--- a/inspector/frontend/src/lib/api/auth-client.ts
+++ b/inspector/frontend/src/lib/api/auth-client.ts
@@ -13,13 +13,21 @@
 import { resetCurrentUser } from '../stores/current-user';
 
 export function signIn(returnPath?: string | null): void {
-    const target = returnPath ?? (typeof window !== 'undefined'
-        ? window.location.pathname + window.location.search
-        : '/');
+    if (typeof window === 'undefined') return;
+    const target = returnPath ?? window.location.pathname + window.location.search;
     const url = `/api/auth/login?return=${encodeURIComponent(target)}`;
-    if (typeof window !== 'undefined') {
-        window.location.assign(url);
+    // Embedded in the huggingface.co iframe the OAuth round-trip is
+    // third-party, so the Flask session cookie carrying the OAuth state is
+    // blocked (Safari ITP rejects it outright despite SameSite=None;Secure),
+    // and Authlib raises MismatchingStateError on the callback. Break the
+    // whole tab out to the first-party *.hf.space origin so authorize→callback
+    // runs top-level and the state cookie survives. Mirrors the QF login
+    // break-out in BookmarksPanel.svelte.
+    if (window.self !== window.top) {
+        window.open(`${window.location.origin}${url}`, '_top');
+        return;
     }
+    window.location.assign(url);
 }
 
 export async function signOut(): Promise<void> {

--- a/inspector/frontend/src/lib/api/auth-client.ts
+++ b/inspector/frontend/src/lib/api/auth-client.ts
@@ -13,21 +13,13 @@
 import { resetCurrentUser } from '../stores/current-user';
 
 export function signIn(returnPath?: string | null): void {
-    if (typeof window === 'undefined') return;
-    const target = returnPath ?? window.location.pathname + window.location.search;
+    const target = returnPath ?? (typeof window !== 'undefined'
+        ? window.location.pathname + window.location.search
+        : '/');
     const url = `/api/auth/login?return=${encodeURIComponent(target)}`;
-    // Embedded in the huggingface.co iframe the OAuth round-trip is
-    // third-party, so the Flask session cookie carrying the OAuth state is
-    // blocked (Safari ITP rejects it outright despite SameSite=None;Secure),
-    // and Authlib raises MismatchingStateError on the callback. Break the
-    // whole tab out to the first-party *.hf.space origin so authorize→callback
-    // runs top-level and the state cookie survives. Mirrors the QF login
-    // break-out in BookmarksPanel.svelte.
-    if (window.self !== window.top) {
-        window.open(`${window.location.origin}${url}`, '_top');
-        return;
+    if (typeof window !== 'undefined') {
+        window.location.assign(url);
     }
-    window.location.assign(url);
 }
 
 export async function signOut(): Promise<void> {

--- a/inspector/routes/auth/auth.py
+++ b/inspector/routes/auth/auth.py
@@ -13,9 +13,9 @@ from __future__ import annotations
 
 import logging
 import os
-from urllib.parse import urljoin, urlparse
+from urllib.parse import parse_qs, urljoin, urlparse
 
-from flask import Blueprint, jsonify, make_response, redirect, request, session
+from flask import Blueprint, jsonify, make_response, redirect, request
 
 from scripts.lib.schemas import ReciterState
 
@@ -65,19 +65,39 @@ def _callback_url() -> str:
     return urljoin(request.url_root, "api/auth/callback")
 
 
+def _state_from_redirect(resp) -> str | None:
+    """Pull the OAuth ``state`` Authlib embedded in the authorize redirect.
+
+    We key the post-login return path on it server-side; see
+    ``auth_service.remember_return_path``.
+    """
+    location = resp.headers.get("Location", "")
+    if not location:
+        return None
+    vals = parse_qs(urlparse(location).query).get("state")
+    return vals[0] if vals else None
+
+
 @auth_bp.route("/auth/login")
 def auth_login():
     if not auth_service.is_oauth_configured():
         return jsonify({"error": "OAuth not configured on this deploy"}), 503
     return_to = _safe_return_path(request.args.get("return"))
-    session["post_login_return"] = return_to
     oauth = auth_service.get_oauth()
     redirect_uri = _callback_url()
+    resp = oauth.huggingface.authorize_redirect(redirect_uri)
+    # Stash the return path server-side, keyed by the freshly-minted OAuth
+    # state. The Flask session cookie can't carry it: inside the cross-site HF
+    # iframe it's third-party and Safari drops it (same reason the OAuth state
+    # itself is now server-side — see services/auth).
+    state = _state_from_redirect(resp)
+    if state:
+        auth_service.remember_return_path(state, return_to)
     logger.info(
         "auth.login url_root=%s host=%s scheme=%s redirect_uri=%s return=%s",
         request.url_root, request.host, request.scheme, redirect_uri, return_to,
     )
-    return oauth.huggingface.authorize_redirect(redirect_uri)
+    return resp
 
 
 @auth_bp.route("/auth/callback")
@@ -99,7 +119,7 @@ def auth_callback():
             "hf_error_description": hf_error_desc,
         }), 400
 
-    return_to = _safe_return_path(session.pop("post_login_return", "/"))
+    return_to = _safe_return_path(auth_service.pop_return_path(request.args.get("state")))
     oauth = auth_service.get_oauth()
     try:
         token = oauth.huggingface.authorize_access_token()

--- a/inspector/services/auth/auth.py
+++ b/inspector/services/auth/auth.py
@@ -1,9 +1,14 @@
 """HF OAuth + signed-cookie session.
 
-Two cookie surfaces:
-- Flask's default ``session`` cookie (signed via ``app.secret_key``) is the
-  short-lived OAuth-state store between ``/authorize`` and ``/callback``
-  (~30 s lifetime). Authlib uses this internally.
+OAuth-state store + one cookie surface:
+- The short-lived OAuth state/nonce between ``/authorize`` and ``/callback``
+  lives in a server-side in-process cache (``_state_cache``), NOT in Flask's
+  session cookie. On HF Spaces the app runs inside a cross-site
+  ``huggingface.co`` iframe where that cookie is third-party and Safari's ITP
+  drops it, so Authlib raised ``MismatchingStateError`` on the callback. A
+  server-side store keeps the embedded login working with no cookie
+  round-trip. Safe because the app is pinned to a single worker (see
+  ``app.py`` ``_assert_single_worker``).
 - ``inspector_session`` cookie signed via ``itsdangerous`` is the long-lived
   (1 week) identity cookie, set after a successful callback. Holds
   ``{login, hf_user_id, iat}``.
@@ -28,10 +33,11 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 import time
 from dataclasses import dataclass
 
-from authlib.integrations.flask_client import OAuth
+from authlib.integrations.flask_client import OAuth, FlaskIntegration
 from flask import request
 from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 
@@ -62,13 +68,120 @@ DEV_ROLE_VALUES = ("owner", "maintainer", "contributor", "anonymous")
 
 _oauth: OAuth | None = None
 
+# TTL for the post-login return path we stash alongside Authlib's own state
+# entry (Authlib's state uses the integration's own expires_in). 10 min
+# comfortably covers a human completing the HF consent screen.
+_RETURN_PATH_TTL = 600
+
+
+class _TTLCache:
+    """Tiny in-process TTL cache for the OAuth state + return path.
+
+    Read/written through ``get(key)`` / ``set(key, value, expires)`` /
+    ``delete(key)`` by ``_CacheStateIntegration`` and the return-path helpers.
+    See the module docstring for why a server-side store is needed on HF
+    Spaces. The single-worker invariant (``app.py``) makes a per-process dict
+    safe.
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[str, tuple[float, object]] = {}
+        self._lock = threading.Lock()
+
+    def get(self, key: str):
+        now = time.time()
+        with self._lock:
+            item = self._store.get(key)
+            if item is None:
+                return None
+            expires_at, value = item
+            if expires_at and expires_at < now:
+                self._store.pop(key, None)
+                return None
+            return value
+
+    def set(self, key: str, value, expires: float | None = None) -> None:
+        expires_at = time.time() + expires if expires else 0.0
+        with self._lock:
+            # Opportunistically drop expired entries so abandoned logins don't
+            # accumulate unbounded.
+            if len(self._store) > 256:
+                now = time.time()
+                self._store = {
+                    k: v for k, v in self._store.items()
+                    if not v[0] or v[0] >= now
+                }
+            self._store[key] = (expires_at, value)
+
+    def delete(self, key: str) -> None:
+        with self._lock:
+            self._store.pop(key, None)
+
+
+_state_cache = _TTLCache()
+
+
+class _CacheStateIntegration(FlaskIntegration):
+    """Keep the OAuth state entirely in ``_state_cache`` — never the session.
+
+    Authlib's stock integration writes an ``exp`` marker to the Flask session
+    even when a ``cache`` is configured, and ``get_state_data`` bails out if
+    that session entry is missing. Inside the cross-site HF iframe the session
+    cookie doesn't round-trip (Safari drops it), so the stock path still raises
+    ``MismatchingStateError``. Overriding the three state hooks to use only the
+    cache makes the callback succeed with no cookie at all.
+    """
+
+    def _state_key(self, state: str) -> str:
+        return f"_state_{self.name}_{state}"
+
+    def get_state_data(self, session, state):  # noqa: ARG002 — session unused by design
+        if not state:
+            return None
+        return self.cache.get(self._state_key(state))
+
+    def set_state_data(self, session, state, data):  # noqa: ARG002
+        self.cache.set(self._state_key(state), data, self.expires_in)
+
+    def clear_state_data(self, session, state):  # noqa: ARG002
+        if state:
+            self.cache.delete(self._state_key(state))
+
+
+class _CacheStateOAuth(OAuth):
+    """Flask ``OAuth`` registry that stores OAuth state server-side."""
+
+    framework_integration_cls = _CacheStateIntegration
+
+
+def remember_return_path(state: str, path: str) -> None:
+    """Stash the post-login return path keyed by the OAuth ``state``.
+
+    Lives alongside Authlib's own state entry in the server-side cache so the
+    callback can recover the redirect target without a session cookie.
+    """
+    _state_cache.set(f"return_{state}", path, _RETURN_PATH_TTL)
+
+
+def pop_return_path(state: str | None) -> str | None:
+    """Return (and clear) the stashed post-login return path, or ``None``."""
+    if not state:
+        return None
+    key = f"return_{state}"
+    val = _state_cache.get(key)
+    _state_cache.delete(key)
+    return val if isinstance(val, str) else None
+
 
 def init_oauth(app) -> OAuth:
     """Register the HF OAuth provider on the Flask app. Idempotent."""
     global _oauth
     if _oauth is not None:
         return _oauth
-    oauth = OAuth(app)
+    # _CacheStateOAuth keeps the OAuth state in _state_cache instead of the
+    # Flask session cookie (third-party and dropped by Safari inside the HF
+    # iframe). The cache is wired in via the registry's `cache` slot.
+    oauth = _CacheStateOAuth(app, cache=_state_cache)
     oauth.register(
         name="huggingface",
         client_id=os.environ.get("OAUTH_CLIENT_ID"),

--- a/inspector/tests/services/test_auth_oauth_state.py
+++ b/inspector/tests/services/test_auth_oauth_state.py
@@ -1,0 +1,56 @@
+"""OAuth state is held server-side, never in the Flask session cookie.
+
+On HF Spaces the app runs inside a cross-site huggingface.co iframe where the
+Flask session cookie is third-party and Safari's ITP drops it. Authlib's stock
+integration keeps an ``exp`` marker in the session even when a cache is wired
+up, so the callback raised ``MismatchingStateError`` whenever that cookie
+failed to round-trip. These tests pin the cookie-free state store and the
+return-path helpers that replaced the session.
+"""
+
+from __future__ import annotations
+
+import os
+
+# auth.py reads the session secret lazily via secrets_guard; seed it so the
+# module imports cleanly under pytest.
+os.environ.setdefault("INSPECTOR_SESSION_SECRET", "0" * 64)
+
+
+def test_state_round_trip_needs_no_session():
+    """set/get/clear work with ``session=None`` — proving the session is never
+    touched. The stock integration would raise on ``None.get(...)``."""
+    from services.auth.auth import _CacheStateIntegration, _TTLCache
+
+    integ = _CacheStateIntegration("huggingface", _TTLCache())
+    data = {"redirect_uri": "https://space.hf.space/api/auth/callback", "nonce": "n-1"}
+
+    integ.set_state_data(None, "state-xyz", data)
+    assert integ.get_state_data(None, "state-xyz") == data
+
+    integ.clear_state_data(None, "state-xyz")
+    assert integ.get_state_data(None, "state-xyz") is None
+
+
+def test_get_state_data_with_empty_state_is_none():
+    from services.auth.auth import _CacheStateIntegration, _TTLCache
+
+    integ = _CacheStateIntegration("huggingface", _TTLCache())
+    assert integ.get_state_data(None, None) is None
+    assert integ.get_state_data(None, "") is None
+
+
+def test_return_path_round_trip_is_single_use():
+    from services.auth import auth as auth_service
+
+    auth_service.remember_return_path("state-ret-1", "/segments/foo")
+    assert auth_service.pop_return_path("state-ret-1") == "/segments/foo"
+    # Consumed on first read so a replayed callback can't reuse it.
+    assert auth_service.pop_return_path("state-ret-1") is None
+
+
+def test_pop_return_path_handles_missing_and_none():
+    from services.auth import auth as auth_service
+
+    assert auth_service.pop_return_path(None) is None
+    assert auth_service.pop_return_path("never-set") is None


### PR DESCRIPTION
## Problem

HF OAuth login fails on the deployed Space with:

```
authlib.integrations.base_client.errors.MismatchingStateError:
mismatching_state: CSRF Warning! State not equal in request and response.
```

The reported failure came from Safari (`Version/26.5 Safari`).

## Root cause

- Authlib stores the OAuth *state* (CSRF token) + nonce in Flask's signed **session cookie**, read back at `/api/auth/callback` to compare against the `state` query param.
- On HF Spaces the app runs **inside a `huggingface.co` iframe**, so that cookie is a **third-party cookie**. Safari's ITP drops third-party cookies outright (regardless of `SameSite=None; Secure`), so the cookie never round-trips → no stored state → `MismatchingStateError`.

## Why "just use a cache" isn't enough

Authlib's Flask integration accepts a `cache=`, but in 1.7.x `get_state_data` **still requires a per-state `exp` marker in the session** even when a cache is configured — so it keeps failing when the session cookie is dropped.

## Fix (keeps login embedded — no iframe break-out)

- Subclass the Flask integration (`_CacheStateIntegration`) to keep the OAuth state **entirely in an in-process TTL cache**, never touching the session. Safe under the existing single-worker invariant (`app.py` `_assert_single_worker`).
- Move the post-login `return` path out of the session too, into the same cache keyed by the OAuth `state`.
- Drop the now-dead `SESSION_COOKIE_SAMESITE/SECURE` config and stale comments.
- Revert the earlier frontend iframe break-out: `signIn()` is a plain same-page redirect again, since the flow no longer depends on any cookie surviving the iframe.
- Quran.Foundation login is unchanged.

## Tests

- New `tests/services/test_auth_oauth_state.py`: state round-trips with `session=None` (proves the session is never touched), empty state → `None`, and the return-path helper is single-use.

## Test plan

- [ ] Open the Space embedded in huggingface.co in **Safari**, sign in, complete HF consent → lands back authenticated (no `MismatchingStateError`).
- [ ] Repeat in Chrome/Firefox embedded — still works.
- [ ] Deep-link return (`?return=/segments/...`) is preserved after login.
- [ ] Direct `*.hf.space` URL (not embedded) sign-in still works.

https://claude.ai/code/session_018imAWoVrARApVeyvvGcn9F