### PR TITLE
fix(board): cut aborted on phantom duration_arithmetic (verse_start_ms=0)

### DIFF
--- a/inspector/routes/webhooks/ts_jobs.py
+++ b/inspector/routes/webhooks/ts_jobs.py
@@ -138,10 +138,15 @@ def release_cut_complete():
     job_id = (body.get("job_id") or "").strip()
     status = (body.get("status") or "").strip().lower()
     version = (body.get("version") or "").strip()
-    if not job_id or not version:
-        return jsonify({"error": "job_id and version are required"}), 400
+    if not job_id:
+        return jsonify({"error": "job_id is required"}), 400
     if status not in _SUCCESS:
+        # A failed/aborted cut posts here for observability only — there's
+        # nothing to record (only successful cuts insert rows) and the version
+        # may be absent (e.g. aborted before it was computed). Don't 400.
         return jsonify({"ok": True, "skipped": "non-success status"})
+    if not version:
+        return jsonify({"error": "version is required"}), 400
     try:
         result = cut_release.complete(
             None, job_id,

--- a/scripts/jobs/cut_release.py
+++ b/scripts/jobs/cut_release.py
@@ -247,6 +247,28 @@ def _build_tier_files(slug: str, verses: dict[str, dict], *,
     }
 
 
+def _verse_for_validate(v: dict, segments: list) -> dict:
+    """Project one canonical verse to the boundary-validator's input shape.
+
+    ``verse_start_ms`` / ``verse_end_ms`` fall back to the word bounds when the
+    verse doesn't carry them (the common projection case). ``duration_ms`` is
+    derived from the SAME resolved bounds — so the duration-arithmetic check
+    (``duration == end - start``) can't fire spuriously on the fallback path.
+    """
+    words = v.get("words") or []
+    vs = v.get("verse_start_ms")
+    vs = int(vs if vs is not None else (words[0][1] if words else 0))
+    ve = v.get("verse_end_ms")
+    ve = int(ve if ve is not None else (max(w[2] for w in words) if words else 0))
+    return {
+        "verse_start_ms": vs,
+        "verse_end_ms": ve,
+        "duration_ms": ve - vs,
+        "words": [(int(w[0]), int(w[1]), int(w[2])) for w in words],
+        "segments": segments,
+    }
+
+
 def _verse_sort_key(key: str) -> tuple[int, int]:
     parts = key.split(":")
     try:
@@ -690,18 +712,7 @@ def main() -> int:
 
         # Boundary validate (source-relative ms — verses dict already in that frame).
         for_validate = {
-            k: {
-                "verse_start_ms": int(v.get("verse_start_ms")
-                                      or (v["words"][0][1] if v.get("words") else 0)),
-                "verse_end_ms": int(v.get("verse_end_ms")
-                                    or (max(w[2] for w in v["words"])
-                                        if v.get("words") else 0)),
-                "duration_ms": int(v.get("verse_end_ms", 0) - v.get("verse_start_ms", 0)
-                                   if isinstance(v, dict) else 0),
-                "words": [(int(w[0]), int(w[1]), int(w[2]))
-                          for w in (v.get("words") or [])],
-                "segments": detailed_segments.get(k, []),
-            }
+            k: _verse_for_validate(v, detailed_segments.get(k, []))
             for k, v in verses.items() if not k.startswith("_") and isinstance(v, dict)
         }
         rec_summary = validate_dataset(for_validate, surah_info=surah_info)

--- a/scripts/lib/tests/test_cut_release_validate.py
+++ b/scripts/lib/tests/test_cut_release_validate.py
@@ -1,0 +1,53 @@
+"""Regression: the cut's boundary-validation input must respect a real
+``verse_start_ms == 0``.
+
+A canonical verse can legitimately start at 0 ms while its first word's audio
+starts a few ms later (leading gap). The old builder used
+``v.get("verse_start_ms") or words[0][1]``, which treats the real ``0`` as
+falsy and substitutes the word start for the *field* — while computing
+``duration_ms`` from the real ``0``. That asymmetry manufactured a phantom
+``duration_arithmetic`` violation and aborted the cut (seen on
+``abu_bakr_al_shatri_tarteel`` 5:1 etc.). ``_verse_for_validate`` resolves the
+bounds once so the three fields always agree.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[3]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from scripts.jobs.cut_release import _verse_for_validate  # noqa: E402
+from scripts.lib.dataset_validation import (  # noqa: E402
+    check_duration_arithmetic,
+)
+
+
+def test_verse_start_zero_with_leading_word_gap():
+    # verse_start_ms is a real 0; first word's audio starts at 60 ms.
+    v = {"verse_start_ms": 0, "verse_end_ms": 24095,
+         "words": [[1, 60, 2350], [23, 21995, 24095]]}
+    out = _verse_for_validate(v, segments=[])
+    assert out["verse_start_ms"] == 0          # NOT coerced to the word start (60)
+    assert out["verse_end_ms"] == 24095
+    assert out["duration_ms"] == 24095          # end - start, consistent
+    assert check_duration_arithmetic("5:1", out) == []   # no phantom violation
+
+
+def test_bounds_fall_back_to_words_when_absent():
+    v = {"words": [[1, 100, 500], [2, 500, 900]]}   # no verse_start/end keys
+    out = _verse_for_validate(v, segments=[])
+    assert out["verse_start_ms"] == 100
+    assert out["verse_end_ms"] == 900
+    assert out["duration_ms"] == 800
+    assert check_duration_arithmetic("1:1", out) == []
+
+
+def test_nonzero_start_duration_consistent():
+    v = {"verse_start_ms": 120, "verse_end_ms": 12814, "words": [[1, 120, 12814]]}
+    out = _verse_for_validate(v, segments=[])
+    assert out["duration_ms"] == 12694
+    assert check_duration_arithmetic("22:1", out) == []


### PR DESCRIPTION
Follow-up to #103. The cut job aborted on `abu_bakr_al_shatri_tarteel` (and others) with 33 fatal `duration_arithmetic` violations — but the data is fine.

**Cause:** the validation-input builder did `v.get("verse_start_ms") or words[0][1]`. A verse can legitimately have `verse_start_ms == 0` (verse starts at 0; first word's audio starts a few ms later). Because `0` is falsy, `or` overrode it with the word start for the *field*, while `duration_ms` was computed from the real `0` → phantom `duration == end` vs `expected == end - start`.

**Fix:** `_verse_for_validate` resolves the bounds once with an `is not None` check, so all three fields agree. Also: the release-cut webhook now requires `version` only for `success` status, so an aborted cut's failure report no longer 400s.

**Verified on live prod data** (ran the job's real `_load_canonical_verses` → `_verse_for_validate` → `validate_dataset` → `fatal_violations` on all 9 GH-eligible reciters): **0 fatal violations across all 9** (was 33 on abu_bakr). New regression test `test_cut_release_validate.py` covers the `verse_start_ms=0` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)