### PR TITLE
Set Space short_description for link embed previews

### DIFF
--- a/inspector/scripts/deploy_space.py
+++ b/inspector/scripts/deploy_space.py
@@ -66,6 +66,7 @@ title: {title}
 emoji: 🎙️
 colorFrom: yellow
 colorTo: indigo
+short_description: Visualize, edit, and verify word- and letter-level Qur'anic recitation timestamps at scale.
 sdk: docker
 app_port: 7860
 pinned: false

--- a/scripts/upload_inspector.py
+++ b/scripts/upload_inspector.py
@@ -65,6 +65,7 @@ title: Quranic Universal Audio{suffix}
 emoji: 🎙️
 colorFrom: yellow
 colorTo: indigo
+short_description: Visualize, edit, and verify word- and letter-level Qur'anic recitation timestamps at scale.
 sdk: docker
 app_port: 7860
 pinned: false


### PR DESCRIPTION
## Problem

When the Space URL (`https://huggingface.co/spaces/hetchyy/quranic-universal-audio`) is pasted into a chat (Discord/Slack/etc.), the link unfurl card shows an unexpected blurb:

> *Enter the chapter or verse you want to hear, and the app streams a high-quality audio recitation of the Quran directly in your browser. No downloads are needed – just listen and enjoy the recitation.*

That text is **not** the Space's on-page description — it's the page's Open Graph `og:description` meta tag, which is what link unfurlers read.

## Cause

For Hugging Face Spaces, `og:description` is sourced from the `short_description` field in the Space `README.md` frontmatter. The frontmatter is generated on every deploy by `scripts/upload_inspector.py` (the `SPACE_README` template) and had **no `short_description`**. When that field is absent, Hugging Face **auto-generates** a description (an AI-written summary) and uses it for `og:description` — hence the surprise text.

Editing the README directly on the Hub wouldn't stick, since the next deploy overwrites it from the template.

## Fix

Add an explicit `short_description` to both Space README templates so embeds show controlled, accurate text:

- `scripts/upload_inspector.py` — prod/dev deploy template
- `inspector/scripts/deploy_space.py` — personal dev deploy template

New value:

> Visualize, edit, and verify word- and letter-level Qur'anic recitation timestamps at scale.

The new description takes effect on the next deploy that pushes the README to the Space.

https://claude.ai/code/session_01JXKeYhBFeRyVn1Uzm9C6QS

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXKeYhBFeRyVn1Uzm9C6QS)_