### PR TITLE
Shorten Space short_description to under 60 chars

### DIFF
--- a/inspector/scripts/deploy_space.py
+++ b/inspector/scripts/deploy_space.py
@@ -66,7 +66,7 @@ title: {title}
 emoji: 🎙️
 colorFrom: yellow
 colorTo: indigo
-short_description: Visualize, edit, and verify word- and letter-level Qur'anic recitation timestamps at scale.
+short_description: Visualize, edit & verify Qur'anic recitation timestamps
 sdk: docker
 app_port: 7860
 pinned: false

--- a/scripts/upload_inspector.py
+++ b/scripts/upload_inspector.py
@@ -65,7 +65,7 @@ title: Quranic Universal Audio{suffix}
 emoji: 🎙️
 colorFrom: yellow
 colorTo: indigo
-short_description: Visualize, edit, and verify word- and letter-level Qur'anic recitation timestamps at scale.
+short_description: Visualize, edit & verify Qur'anic recitation timestamps
 sdk: docker
 app_port: 7860
 pinned: false


### PR DESCRIPTION
## Problem

The deploy on `main` failed after #110: Hugging Face caps the Space `short_description` at **under 60 characters**, and the value introduced in #110 was ~88 chars.

## Fix

Trim `short_description` to a 55-character tool-focused summary in both Space README templates:

- `scripts/upload_inspector.py` (prod/dev deploy)
- `inspector/scripts/deploy_space.py` (personal dev deploy)

New value (55 chars):

> Visualize, edit & verify Qur'anic recitation timestamps

This stays under the 60-char limit, so the deploy passes, and it displays cleanly in the Space card without truncation.

https://claude.ai/code/session_01JXKeYhBFeRyVn1Uzm9C6QS

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXKeYhBFeRyVn1Uzm9C6QS)_