### PR TITLE
Audio: dashboard prewarming, waveform alignment, and playback reliability

### DIFF
--- a/.claude/skills/inspector-audio/references/backend.md
+++ b/.claude/skills/inspector-audio/references/backend.md
@@ -32,6 +32,8 @@ Optional `?download=1` (+ `&chapter=<n>`) makes every tier emit `Content-Disposi
 
 `routes/audio/metadata.py` — `audio_surahs(...)`, `audio_meta_bp` (`url_prefix=/api/audio`). `GET /api/audio/surahs/<category>/<source>/<slug>` returns per-chapter `{url, duration_ms}` for the dashboard `BottomPlayer`, with `_apply_qf_routing` swapping in Quran-Foundation Content-API URLs where applicable. (Distinct from the seg-tab routes; easy to miss.)
 
+`duration_ms` is derived from the manifest's `duration_sec`. **Fallback:** when a chapter's manifest duration is null/missing, the route reads the duration baked into the slim peaks header (`reciters/<slug>/peaks/<ch>.json.gz`) via `audio_fetch.read_prefetched_peaks_duration_ms` — so a reciter probed before the manifest carried durations still shows a real scrubber length instead of 0:00. Stays `null` only when peaks are also absent. (QF-routed chapters keep `duration_ms=null` on purpose — `_apply_qf_routing` nulls it because the `/qdc/` re-encodes differ in length; it runs after the peaks fallback.)
+
 ## Audio source resolver
 
 `services/audio/audio_source.py` is the single chokepoint every backend audio consumer (proxy, peaks decode, clip) goes through. Answers two questions for a `(reciter, url)` pair: *where do this chapter's bytes live right now?* and *is this chapter VBR?*

--- a/.claude/skills/inspector-audio/references/frontend.md
+++ b/.claude/skills/inspector-audio/references/frontend.md
@@ -11,7 +11,7 @@ For VBR-specific port behavior see `vbr.md`.
 | Port | Module | Drives | Kill-switch |
 |---|---|---|---|
 | `segPort` | `tabs/segments/stores/playback.ts` (`new AudioPort()`) | Segments tab | enabled (proxied same-origin URLs) |
-| `dashPort` | `lib/playback/dash-port.ts` | **Dashboard AND Timestamps** (via `BottomPlayer`); supports `adoptElement` gapless swaps; `TimestampsWaveform` reads `dashPort.currentTimeMs()` for karaoke | `disableKillSwitch: true` (can hit a 302→CDN fallback) |
+| `dashPort` | `lib/playback/dash-port.ts` | **Dashboard AND Timestamps** (via `BottomPlayer`); supports `adoptElement` gapless swaps; `TimestampsWaveform` reads `dashPort.currentTimeMs()` for karaoke | `disableKillSwitch: true` (some sources are RAW cross-origin `qf_api` links, not proxied) |
 | `tsPort` | `tabs/timestamps/stores/playback.ts` | nothing — vestigial; delete or rewire | — |
 | per-panel | `tabs/segments/utils/playback/preview.ts` (`new AudioPort()`) | SavePreview / HistoryPanel, isolated from live `playingSegmentIndex` | enabled |
 
@@ -60,7 +60,7 @@ Subscriber API (each returns an unsubscribe fn, snapshotted before fanout): `onL
 
 ### Cross-origin gotcha (`disableKillSwitch`)
 
-`MediaElementAudioSourceNode` requires CORS to read samples; constructing one against a cross-origin URL without CORS silently mutes (Web Audio spec). **The audio-proxy now streams same-origin with `ACAO: *`** (`routes/audio/proxy.py`), so `crossorigin="anonymous"` elements playing **proxied** URLs route through Web Audio fine — the foot-gun is mostly defused. `disableKillSwitch: true` (skips Web Audio entirely; the audible-tail bug at pause returns) is now needed only for **raw cross-origin URLs not wrapped by the proxy** — which is why `dashPort` keeps it (302→CDN fallback). Wrap CBR by_surah URLs via `wrapCbrSrcIfBySurah` (`source.ts`) and keep the kill-switch.
+`MediaElementAudioSourceNode` requires CORS to read samples; constructing one against a cross-origin URL without CORS silently mutes (Web Audio spec). **The audio-proxy now streams same-origin with `ACAO: *`** (`routes/audio/proxy.py`), so `crossorigin="anonymous"` elements playing **proxied** URLs route through Web Audio fine — the foot-gun is mostly defused. `disableKillSwitch: true` (skips Web Audio entirely; the audible-tail bug at pause returns) is now needed only for **raw cross-origin URLs not wrapped by the proxy** — which is why `dashPort` keeps it (some dashboard sources are raw `qf_api` Quran.Foundation links served directly, not through the proxy). Wrap CBR by_surah URLs via `wrapCbrSrcIfBySurah` (`source.ts`) and keep the kill-switch.
 
 ## AudioGraph (Web Audio kill-switch)
 
@@ -97,8 +97,9 @@ cutAudio(el) / uncutAudio(el) // 5 ms ramp to 0 / 1
 For cross-source jumps where the once-per-element constraint forbids re-using one element (TS shuffle / auto-advance):
 
 - `lib/playback/shadow-audio.ts` — warm a hidden `<audio>` element (`shadowPrewarm(url, {slot, seekSec})`, slots `'any'`/`'shuf'`), then `consumeWarm(url)` hands it over and `recycleAsShadow(el, slot)` returns the old one to the pool.
-- `lib/playback/shuffle-prewarm.ts` — thin wrapper remembering which `TsRandomTarget` a warm URL belongs to (`primeShuffle`/`consumeShuffle`/`clearShuffle`).
-- `lib/playback/adopt-signal.ts` — module-level single-shot signal so `BottomPlayer.reactToContext` skips a reload after a gapless adopt (`setAdoptedSource`/`takeAdoptedSource`).
+- `lib/playback/shuffle-prewarm.ts` — thin wrapper remembering which `TsRandomTarget` a warm URL belongs to (`primeShuffle`/`consumeShuffle`/`clearShuffle`). Slot `'shuf'`.
+- `lib/playback/dash-prewarm.ts` — the **dashboard intent-driven look-ahead** (slot `'dash'`, depth 1). Two tiers: `primeDashSpeculative(url, seekSec)` (range-windowed warm for hovers — next/prev button, surah popover, progress bar, filmstrip cell, scrub-settle) and `primeDashCommitted(target)` + `consumeDashCommitted(url)` (full-element warm for the imminent gapless-next chapter, adopted on `dashPort.onEnded`). `clearDashPrewarm()` cancels on reciter/chapter switch. Wired from `BottomPlayer.svelte` (+ `NowReciting`/`AyahFilmstrip` for the filmstrip-hover hook). A committed target outranks speculative hovers (single slot).
+- `lib/playback/adopt-signal.ts` — module-level single-shot signal so `BottomPlayer.reactToContext` skips a reload after a gapless adopt (`setAdoptedSource`/`takeAdoptedSource`). Used by BOTH the TS shuffle adopt and the dashboard gapless-next adopt.
 - `port.adoptElement(el, srcUrl)` transplants the warm element; the kill-switch graph rides along on the element.
 
 ## Segment look-ahead warming (CBR)
@@ -125,6 +126,8 @@ For cross-source jumps where the once-per-element constraint forbids re-using on
 ## Feature-building seams
 
 - **New AudioPort consumer:** import/construct a module-scoped port, `attachElement` on mount, `setSource` → `loadCovering` → `await ready` → `seekAndPlay` (file-absolute ms). Gapless cross-source → prewarm via `shadow-audio.ts` + `adoptElement`.
+- **Dashboard loading ring:** `BottomPlayer` gates `isLoading` on `onPlaying` (actual audible resume) as the single steady-state clear — NOT `onLoad`/canplay (readyState 3 ≠ audible; clearing there stops the ring 1–3 s early). `onWaiting` re-raises on a mid-play stall. A paused chapter-select fires `dashPort.prewarm()` so the play-click isn't a cold start.
+- **New intent-prewarm signal (dashboard):** call `primeDashSpeculative` (hover) or `primeDashCommitted` (committed) from `dash-prewarm.ts`; keep depth 1 (single `'dash'` slot) and `clearDashPrewarm()` on source switch so a stale warm can't adopt.
 - **New peaks consumer:** `getWaveformPeaks(url)` → `viewPeaks(...)` → draw. Decode wire only via `b64ToInt8`. Never branch on peaks shape at the call site.
 - **New boundary policy:** extend the `RangePolicy` union + add a `case` in `_handleBoundary()`; honor the live-element reads so adopt rotation doesn't break it.
 - **New tab's playback:** mirror `dashPort`/`segPort` — module-scoped port in a `stores/playback.ts`, component `attachElement`s a `<audio crossorigin="anonymous">`, a `*PortReady` writable, App-level tab-switch `port.pause()`. Keep the kill-switch on unless it plays raw cross-origin audio.

--- a/inspector/frontend/src/lib/components/player/BottomPlayer.svelte
+++ b/inspector/frontend/src/lib/components/player/BottomPlayer.svelte
@@ -15,11 +15,19 @@
 
     import { clickOutside } from '../../actions/click-outside';
     import { fetchSurahsForDelivery, type SurahEntry } from '../../api/audio-surahs';
-    import { takeAdoptedSource } from '../../playback/adopt-signal';
+    import { setAdoptedSource, takeAdoptedSource } from '../../playback/adopt-signal';
     import { ensureAudioContextRunning } from '../../playback/audio-graph';
     import { adjacentAyahStartMs, nearestAyahStartMs } from '../../playback/ayah-seek';
+    import {
+        clearDashPrewarm,
+        consumeDashCommitted,
+        dashProxyUrl,
+        primeDashCommitted,
+        primeDashSpeculative,
+    } from '../../playback/dash-prewarm';
     import { dashPort } from '../../playback/dash-port';
-    import { exitLoop } from '../../playback/loop';
+    import { exitLoop, loopTarget } from '../../playback/loop';
+    import { recycleAsShadow } from '../../playback/shadow-audio';
     import { recitationAyahStarts } from '../../recitation-animation/recitation-settings';
     import {
         loadPersistedSlice,
@@ -31,7 +39,10 @@
         setPosition,
         setSpeed,
     } from '../../stores/player-context';
+    import { progressHoverMs, progressScrubMs } from '../../stores/progress-hover';
     import type { PublicDelivery } from '../../types/public-state';
+    import { getActiveTab } from '../../utils/active-tab';
+    import { TAB_NAMES } from '../../utils/constants';
     import { DASHBOARD_SPEEDS } from '../../utils/speed-control';
     import PlayerControls from './PlayerControls.svelte';
     import PlayerMetaChip from './PlayerMetaChip.svelte';
@@ -43,6 +54,9 @@
     let lastDeliverySlug: string | null = null;
     let lastSurahNum: number | null = null;
     let surahPopoverOpen = false;
+    // WS6 intent-prewarm state (helpers + constants below reactToContext).
+    let _warmDebounce: ReturnType<typeof setTimeout> | null = null;
+    let _nearEndWarmedSurah: number | null = null;
 
     onMount(() => {
         dashPort.attachElement(audioEl);
@@ -58,18 +72,29 @@
             // leaving the template-bound `audioEl` stale.
             const dur = dashPort.element?.duration ?? 0;
             setPosition(0, Number.isFinite(dur) ? dur * 1000 : 0);
-            // Swap-complete (canplay): if the user wasn't already in a
-            // mid-play buffering stall, this is the moment audio is ready
-            // to start. Clear the ring; `playing` will also clear it on
-            // the actual audible start as a safety net.
-            setIsLoading(false);
+            // NOTE: canplay (readyState 3) is NOT audible — clearing the ring
+            // here stops it 1-3s before sound. `onPlaying` is the single
+            // steady-state clear (actual audible resume); see it below.
         });
         const unsubTime = dashPort.onTimeUpdate((fileMs) => {
             const dur = dashPort.element?.duration;
             setPosition(fileMs, dur ? dur * 1000 : undefined);
+            maybeWarmNext(fileMs, dur ? dur * 1000 : 0);
         });
         const unsubWaiting = dashPort.onWaiting(() => setIsLoading(true));
+        // Single steady-state clear: the ring stays up from the play request
+        // until audio is actually audible (`playing`), not merely buffered
+        // (`canplay`). `onWaiting` re-raises it on a mid-play decoder stall.
         const unsubPlaying = dashPort.onPlaying(() => setIsLoading(false));
+        // Chapter-end gapless auto-advance (Dashboard tab only — on Timestamps,
+        // the shuffle handler owns end-of-chapter; see TimestampsTab onEnded).
+        const unsubEnded = dashPort.onEnded(() => advanceGaplessOnEnd());
+
+        // Speculative warm around the hovered / scrubbed position of the current
+        // chapter (warms canplay so a cold first seek isn't a 1-3s stall). Both
+        // share the same debounce; null (hover-leave / scrub-release) no-ops.
+        const unsubHover = progressHoverMs.subscribe((ms) => warmAtPositionDebounced(ms));
+        const unsubScrub = progressScrubMs.subscribe((ms) => warmAtPositionDebounced(ms));
 
         return () => {
             unsubPlay();
@@ -78,6 +103,11 @@
             unsubTime();
             unsubWaiting();
             unsubPlaying();
+            unsubEnded();
+            unsubHover();
+            unsubScrub();
+            if (_warmDebounce) clearTimeout(_warmDebounce);
+            clearDashPrewarm();
             dashPort.attachElement(null);
         };
     });
@@ -154,6 +184,11 @@
                 setIsPlaying(true);
                 return;
             }
+            // Real source switch (not the adopt fast-path above): cancel any
+            // in-flight speculative/committed warm so a stale warm element can
+            // never adopt onto the new source. Mirrors shuffle's clearShuffle.
+            clearDashPrewarm();
+            _nearEndWarmedSurah = null;
             // Stop the previous chapter immediately. Without this, the
             // old MP3 keeps playing until _swapTo writes el.src for the
             // new source — audible as a chunk of the wrong reciter when
@@ -193,6 +228,12 @@
                     await ensureAudioContextRunning();
                     dashPort.loadCovering(0, Number.POSITIVE_INFINITY);
                     dashPort.play();
+                } else {
+                    // Paused chapter-select: warm the decoder + canplay off the
+                    // play-click critical path so first-play isn't a 1-3s cold
+                    // start (fetch + header parse + decode). No-op for VBR;
+                    // dashboard sources are always CBR. Fire-and-forget.
+                    void dashPort.prewarm();
                 }
             }
             lastSurahNum = surahNum;
@@ -202,6 +243,126 @@
             // write captures the surah actually loaded (and surah-only changes).
             persistSlice({ deliverySlug: delivery.slug, surahNum, speed: ctx.speed });
         }
+    }
+
+    // ---------------------------------------------------------------------
+    // Intent-driven prewarm (WS6). Depth 1, single 'dash' shadow slot.
+    // Speculative (hover) = range-windowed warm; committed (near-end) = the
+    // imminent gapless-next chapter, adopted on `ended`. Cancel-on-switch
+    // lives in reactToContext. See lib/playback/dash-prewarm.ts.
+    // ---------------------------------------------------------------------
+    /** Warm the committed next chapter once the current one is within this much
+     *  of its end, so the chapter-end handoff can adopt it gaplessly. */
+    const NEAR_END_WARM_MS = 12_000;
+    /** Debounce window for the speculative position-warm (progress hover / scrub
+     *  settle) so a fast scrub doesn't stack proxy fetches. */
+    const POSITION_WARM_DEBOUNCE_MS = 150;
+
+    /** Proxy URL for a given surah's chapter MP3 (current delivery), or null
+     *  when the surah isn't in the loaded set. */
+    function surahProxyUrl(n: number): string | null {
+        const delivery = $playerContext.delivery;
+        const entry = urls[String(n)];
+        if (!delivery || !entry) return null;
+        return dashProxyUrl(delivery.slug, entry.url);
+    }
+
+    function nextSurahNum(): number | null {
+        const cur = $playerContext.surahNum;
+        if (cur === null) return null;
+        const idx = surahNums.indexOf(cur);
+        return idx >= 0 && idx < surahNums.length - 1 ? surahNums[idx + 1]! : null;
+    }
+
+    function prevSurahNum(): number | null {
+        const cur = $playerContext.surahNum;
+        if (cur === null) return null;
+        const idx = surahNums.indexOf(cur);
+        return idx > 0 ? surahNums[idx - 1]! : null;
+    }
+
+    /** Speculative: warm a whole surah's start (next/prev button + popover hover). */
+    function warmSurah(n: number | null): void {
+        if (n === null) return;
+        const proxy = surahProxyUrl(n);
+        if (proxy) primeDashSpeculative(proxy, 0);
+    }
+
+    /** Speculative: warm the CURRENT chapter at a hovered/scrubbed file-ms
+     *  position (debounced). No-op once the chapter is already loaded — the
+     *  shadow dedupe + warm only helps the cold first seek. */
+    function warmAtPositionDebounced(fileMs: number | null): void {
+        if (fileMs === null || !Number.isFinite(fileMs)) return;
+        const cur = $playerContext.surahNum;
+        if (cur === null) return;
+        const proxy = surahProxyUrl(cur);
+        if (!proxy) return;
+        if (_warmDebounce) clearTimeout(_warmDebounce);
+        _warmDebounce = setTimeout(() => {
+            primeDashSpeculative(proxy, Math.max(0, fileMs / 1000));
+        }, POSITION_WARM_DEBOUNCE_MS);
+    }
+
+    /** Near-end: commit-warm the next chapter so `ended` can adopt it gaplessly.
+     *  Dashboard tab only (Timestamps' shuffle owns end-of-chapter). Skips while
+     *  looping (the chapter repeats) and after the next chapter is already warm. */
+    function maybeWarmNext(fileMs: number, durationMs: number): void {
+        if (getActiveTab() !== TAB_NAMES.DASHBOARD) return;
+        if ($loopTarget || durationMs <= 0) return;
+        const cur = $playerContext.surahNum;
+        if (cur === null || _nearEndWarmedSurah === cur) return;
+        if (fileMs < durationMs - NEAR_END_WARM_MS) return;
+        const nextN = nextSurahNum();
+        const delivery = $playerContext.delivery;
+        if (nextN === null || !delivery) return;
+        const entry = urls[String(nextN)];
+        if (!entry) return;
+        _nearEndWarmedSurah = cur;
+        primeDashCommitted({
+            deliverySlug: delivery.slug,
+            surahNum: nextN,
+            rawUrl: entry.url,
+            proxyUrl: dashProxyUrl(delivery.slug, entry.url),
+        });
+    }
+
+    /** Chapter-end handoff (Dashboard tab only). If the next chapter is warm,
+     *  adopt its element onto dashPort and start it gaplessly, then advance
+     *  playerContext (guarded by the adopt signal so reactToContext does
+     *  bookkeeping only). Else fall back to a plain (gapped) auto-advance. */
+    function advanceGaplessOnEnd(): void {
+        if (getActiveTab() !== TAB_NAMES.DASHBOARD) return;
+        if ($loopTarget) return;
+        const delivery = $playerContext.delivery;
+        const nextN = nextSurahNum();
+        _nearEndWarmedSurah = null;
+        if (!delivery || nextN === null) return;
+        const entry = urls[String(nextN)];
+        if (!entry) return;
+        const proxyUrl = dashProxyUrl(delivery.slug, entry.url);
+
+        const consumed = consumeDashCommitted(proxyUrl);
+        if (consumed && consumed.surahNum === nextN) {
+            // Match the triple reactToContext would build so its eventual
+            // setSource is a guaranteed no-op alongside the adopt signal.
+            dashPort.setSource({
+                audioUrl: consumed.rawUrl, cbrSrc: consumed.proxyUrl,
+                reciter: delivery.slug, vbr: false,
+            });
+            setAdoptedSource({ deliverySlug: delivery.slug, surahNum: nextN, srcUrl: proxyUrl });
+            const oldEl = dashPort.element;
+            dashPort.adoptElement(consumed.el, proxyUrl);
+            if (oldEl && oldEl !== consumed.el) recycleAsShadow(oldEl, 'any');
+            dashPort.seekAndPlay(0);
+            setIsLoading(false);
+            setIsPlaying(true);
+            playerContext.update((s) => ({
+                ...s, surahNum: nextN, positionMs: 0, isPlaying: true,
+            }));
+            return;
+        }
+        // Look-ahead miss → plain (gapped) advance.
+        setSurahAndResume(nextN);
     }
 
     async function togglePlay(): Promise<void> {
@@ -411,6 +572,7 @@
                             surahNums={surahNums}
                             value={$playerContext.surahNum}
                             on:change={onSurahChange}
+                            on:hover={(ev) => warmSurah(ev.detail)}
                         />
                     </div>
                 {/if}
@@ -432,6 +594,8 @@
                 on:seekForward={seekForward}
                 on:prev={prevSurah}
                 on:next={nextSurah}
+                on:prevHover={() => warmSurah(prevSurahNum())}
+                on:nextHover={() => warmSurah(nextSurahNum())}
             />
         </div>
 

--- a/inspector/frontend/src/lib/components/player/NowReciting.svelte
+++ b/inspector/frontend/src/lib/components/player/NowReciting.svelte
@@ -114,6 +114,14 @@
         }
     }
 
+    // Speculative prewarm on filmstrip ayah-cell hover. The hovered ayah is in
+    // the CURRENT chapter (already the bound source), so a `prewarm()` warms its
+    // decoder + canplay if the chapter hasn't played yet — a no-op (fast-path
+    // reuse) once it has, and a no-op for VBR. Cheap to call per cell.
+    function warmCurrentChapter(): void {
+        void dashPort.prewarm();
+    }
+
     // Load chapter recitation when the published reciter / surah changes.
     $effect(() => {
         if (!isPublished || !reciterSlug || !surahNum) {
@@ -302,6 +310,7 @@
                         hoverMs={$progressHoverMs}
                         scrubMs={$progressScrubMs}
                         onSeek={seek}
+                        onHoverPrewarm={warmCurrentChapter}
                     />
                 </div>
             </div>

--- a/inspector/frontend/src/lib/components/player/PlayerControls.svelte
+++ b/inspector/frontend/src/lib/components/player/PlayerControls.svelte
@@ -11,6 +11,8 @@
     const dispatch = createEventDispatcher<{
         prev: void;
         next: void;
+        prevHover: void;
+        nextHover: void;
         seekBack: void;
         seekForward: void;
         toggle: void;
@@ -24,6 +26,8 @@
         aria-label="Previous surah"
         disabled={!canStepBack}
         on:click={() => dispatch('prev')}
+        on:pointerenter={() => dispatch('prevHover')}
+        on:focus={() => dispatch('prevHover')}
     >⏮</button>
     <button type="button" class="btn" aria-label="Back 15 seconds" on:click={() => dispatch('seekBack')}>«</button>
     <button
@@ -42,6 +46,8 @@
         aria-label="Next surah"
         disabled={!canStepForward}
         on:click={() => dispatch('next')}
+        on:pointerenter={() => dispatch('nextHover')}
+        on:focus={() => dispatch('nextHover')}
     >⏭</button>
 </div>
 

--- a/inspector/frontend/src/lib/components/player/SurahPopover.svelte
+++ b/inspector/frontend/src/lib/components/player/SurahPopover.svelte
@@ -40,10 +40,14 @@
         ? items.filter((it) => it.label.toLowerCase().includes(query.trim().toLowerCase()))
         : items;
 
-    const dispatch = createEventDispatcher<{ change: number }>();
+    const dispatch = createEventDispatcher<{ change: number; hover: number }>();
 
     function pick(n: number): void {
         dispatch('change', n);
+    }
+
+    function hover(n: number): void {
+        dispatch('hover', n);
     }
 
     function onKeydown(ev: KeyboardEvent): void {
@@ -72,6 +76,8 @@
                 role="option"
                 aria-selected={value === it.n}
                 on:click={() => pick(it.n)}
+                on:pointerenter={() => hover(it.n)}
+                on:focus={() => hover(it.n)}
             >
                 <span class="num">{it.n}</span>
                 <span class="names">

--- a/inspector/frontend/src/lib/playback/dash-port.ts
+++ b/inspector/frontend/src/lib/playback/dash-port.ts
@@ -1,25 +1,25 @@
 /**
- * Dashboard-tab AudioPort instance.
+ * Dashboard-tab AudioPort instance — shared by the Dashboard AND Timestamps
+ * tabs via `BottomPlayer` (one element + transport so tab-switching cleanly
+ * pauses one surface without touching the other).
  *
- * Mirrors the per-tab pattern used by `audPort` (audio tab),
- * `segPort` (segments tab), and `tsPort` (timestamps tab). No global
- * port — each tab owns its element + transport so tab-switching
- * cleanly pauses one without touching the others.
+ * Dashboard plays full chapter MP3s (no VBR clip routing); the port is here
+ * for transport uniformity and for App.svelte's tab-switch pause path. It
+ * also supports `adoptElement` for the Timestamps gapless-shuffle swap.
  *
- * Dashboard plays full chapter MP3s (no VBR clip routing); the port
- * is here for transport uniformity and for App.svelte's tab-switch
- * pause path.
- *
- * Kill-switch is intentionally disabled. The dashboard hits chapter
- * URLs through `/api/seg/audio-proxy/...` which returns 302 to the
- * source CDN when the bucket prefetch hasn't covered the slug — every
- * un-prefetched reciter in dashboard browsing. Constructing a
- * `MediaElementAudioSourceNode` on a cross-origin element silences
- * playback per the Web Audio spec (no CORS approval on the CDN
- * response). Full-chapter playback doesn't need sample-accurate end-
- * of-region cutoff, so we keep the element on its default audio sink.
+ * Kill-switch is intentionally disabled. Chapter URLs go through
+ * `/api/seg/audio-proxy/...`, whose CDN tier is a SAME-ORIGIN 200/206 stream
+ * with `Access-Control-Allow-Origin: *` (no 302 redirect) — so proxied URLs
+ * would route through `MediaElementAudioSourceNode` fine. But some dashboard
+ * sources are RAW cross-origin (Quran.Foundation `qf_api` links served
+ * directly, not via the proxy), and constructing a `MediaElementAudioSourceNode`
+ * on a cross-origin element silences playback per the Web Audio spec. Full-
+ * chapter playback doesn't need sample-accurate end-of-region cutoff, so we
+ * keep the element on its default audio sink across the board.
  */
 
 import { AudioPort } from './audio-port';
 
 export const dashPort: AudioPort = new AudioPort({ disableKillSwitch: true });
+
+if (import.meta.env.DEV) (globalThis as Record<string, unknown>).__dashPort = dashPort;

--- a/inspector/frontend/src/lib/playback/dash-prewarm.ts
+++ b/inspector/frontend/src/lib/playback/dash-prewarm.ts
@@ -1,0 +1,110 @@
+/**
+ * Dashboard intent-driven look-ahead — keeps ONE warm `<audio>` element decoded
+ * (and optionally seeked) for the chapter the user is most likely to play next,
+ * so the play-click pays no cold-start (fetch + header parse + decode + canplay).
+ *
+ * Depth 1, single slot ('dash'): each intent replaces the prior warm target.
+ * Two confidence tiers, matching the locked decision:
+ *   - SPECULATIVE (`primeDashSpeculative`) — hovers over the next/prev button,
+ *     a surah in the popover, the progress bar, or a filmstrip ayah. A cheap
+ *     range-windowed warm (`shadowPrewarm` sets src + seeks → HTTP Range), no
+ *     commitment.
+ *   - COMMITTED (`primeDashCommitted`) — the imminent gapless-next chapter as
+ *     the current surah nears its end. Same warm, but tracked as consumable so
+ *     the near-end handoff can `consumeDashCommitted` → `adoptElement` the warm
+ *     element gaplessly (mirrors the Timestamps shuffle adopt path).
+ *
+ * A committed target supersedes a speculative one (commitment wins the single
+ * slot). `clearDashPrewarm()` cancels the in-flight warm on a reciter/chapter
+ * switch so a stale warm can never be adopted (mirrors shuffle-prewarm's
+ * `clearShuffle`).
+ *
+ * Thin wrapper over `shadow-audio.ts`: the shadow pool keys by URL only, so
+ * this module remembers WHICH chapter the committed URL belongs to for the
+ * adopt-time `setSource` triple + `playerContext` follow.
+ */
+import { cancelWarm, consumeWarm, shadowPrewarm } from './shadow-audio';
+
+/** HTMLMediaElement.HAVE_CURRENT_DATA — enough decoded to play at the position. */
+const HAVE_CURRENT_DATA = 2;
+/** Dedicated shadow slot for the dashboard look-ahead (distinct from 'shuf'
+ *  and the 'any' recycle bin). */
+const DASH_SLOT = 'dash' as const;
+
+/** A committed gapless-next target — the chapter the near-end handoff will
+ *  adopt. */
+export interface DashCommitted {
+    deliverySlug: string;
+    surahNum: number;
+    /** Raw (un-proxied) chapter URL — for the adopt-time `setSource` triple. */
+    rawUrl: string;
+    /** Proxy URL the warm element is loaded with (matches what BottomPlayer
+     *  would build) — the shadow-pool consume key + `adoptElement` src. */
+    proxyUrl: string;
+}
+
+let _committed: DashCommitted | null = null;
+
+/** Build the same proxy URL BottomPlayer / TimestampsTab build for a chapter
+ *  CDN link. Already-proxied (`/api/...`) URLs pass through untouched. */
+export function dashProxyUrl(slug: string, rawUrl: string): string {
+    return rawUrl.startsWith('/api/')
+        ? rawUrl
+        : `/api/seg/audio-proxy/${slug}?url=${encodeURIComponent(rawUrl)}`;
+}
+
+/** Speculative warm — range-windowed decode at `seekSec` (default 0). Replaces
+ *  any prior warm in the slot, BUT never displaces a committed target (a
+ *  commitment outranks a hover). No-op for an empty URL. */
+export function primeDashSpeculative(proxyUrl: string, seekSec = 0): void {
+    if (!proxyUrl || _committed) return;
+    shadowPrewarm(proxyUrl, { slot: DASH_SLOT, seekSec: Math.max(0, seekSec) });
+}
+
+/** Committed warm — the imminent gapless-next chapter. Tracks the target for
+ *  adopt. Replaces any prior (speculative or committed) warm. Re-calling with
+ *  the SAME proxy URL is a no-op (shadow dedupe). */
+export function primeDashCommitted(c: DashCommitted): void {
+    if (!c.proxyUrl) return;
+    if (_committed?.proxyUrl === c.proxyUrl) return;
+    _committed = c;
+    shadowPrewarm(c.proxyUrl, { slot: DASH_SLOT, seekSec: 0 });
+}
+
+export interface ConsumedDash extends DashCommitted {
+    el: HTMLAudioElement;
+}
+
+/**
+ * Consume the committed target + its warm element, IFF the element is decoded
+ * to a playable state. Returns null on a miss (no committed target, URL drift,
+ * or element not ready) so the caller falls back to a plain (gapped) load. A
+ * not-ready element is torn down rather than adopted (adopting a cold element
+ * gaps worse than a fresh load).
+ */
+export function consumeDashCommitted(proxyUrl: string): ConsumedDash | null {
+    const c = _committed;
+    _committed = null;
+    if (!c || c.proxyUrl !== proxyUrl) return null;
+    const el = consumeWarm(proxyUrl);
+    if (!el) return null;
+    if (el.readyState < HAVE_CURRENT_DATA) {
+        try {
+            el.removeAttribute('src');
+            el.load();
+            el.remove();
+        } catch {
+            /* ignore */
+        }
+        return null;
+    }
+    return { ...c, el };
+}
+
+/** Abandon any pending dashboard warmup — the committed-target ref AND the
+ *  shadow element's in-flight fetch. Called on a reciter/chapter switch so a
+ *  stale warm never adopts and rapid hovers don't stack audio-proxy sockets. */
+export function clearDashPrewarm(): void {
+    _committed = null;
+    cancelWarm(DASH_SLOT);
+}

--- a/inspector/frontend/src/lib/playback/shadow-audio.ts
+++ b/inspector/frontend/src/lib/playback/shadow-audio.ts
@@ -3,8 +3,9 @@
  * upcoming verse plays AND get adopted as the active playback element on
  * consume.
  *
- * Slots: 'any' (recycle bin for the formerly-visible element) and 'shuf' (the
- * shuffle look-ahead — one target for the current mode).
+ * Slots: 'any' (recycle bin for the formerly-visible element), 'shuf' (the
+ * shuffle look-ahead — one target for the current mode), and 'dash' (the
+ * dashboard intent-driven look-ahead — one committed gapless-next target).
  * Each slot holds a hidden `<audio crossorigin='anonymous' preload='auto'>`
  * loaded with a URL and seeked to the verse start, so by the time the user
  * clicks Random / auto-advance fires:
@@ -26,7 +27,7 @@
 
 const DEDUPE_MS = 30_000;
 
-type SlotKey = 'any' | 'shuf';
+type SlotKey = 'any' | 'shuf' | 'dash';
 
 interface Slot {
     el: HTMLAudioElement;

--- a/inspector/frontend/src/lib/recitation-animation/AyahFilmstrip.svelte
+++ b/inspector/frontend/src/lib/recitation-animation/AyahFilmstrip.svelte
@@ -28,10 +28,16 @@
          *  motion modes) while non-null, suspending the playback driver. null =
          *  not scrubbing. */
         scrubMs?: number | null;
+        /** Speculative-prewarm hook: fired with a cell's start (ms) when the
+         *  pointer enters it, so the surface can warm that position. Optional —
+         *  surfaces that don't prewarm omit it. */
+        onHoverPrewarm?: (_ms: number) => void;
     }
 
-    let { ayahs, getTimeMs, playing, config, onSeek, hoverMs = null, scrubMs = null }: Props =
-        $props();
+    let {
+        ayahs, getTimeMs, playing, config, onSeek,
+        hoverMs = null, scrubMs = null, onHoverPrewarm,
+    }: Props = $props();
 
     const clamp = (lo: number, hi: number, v: number): number => Math.min(hi, Math.max(lo, v));
     const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
@@ -240,15 +246,29 @@
     }
     function clickToSeek(clientX: number): void {
         if (!containerEl) return;
-        const rect = containerEl.getBoundingClientRect();
-        // viewport-x → offset into cells region (needle is at cw/2; track is
-        // translated by -offset; leading pad = cw/2).
-        const off = clientX - rect.left + offset - cw / 2;
-        const i = nearestCell(clamp(0, lastRight, off));
+        const i = cellAtClientX(clientX);
         if (i < 0) return;
         animate = true;
         offset = offsetForCellCenter(i);
         onSeek(cells[i]!.startMs);
+    }
+
+    /** Map a viewport x to the cell index under it (needle at cw/2; track
+     *  translated by -offset; leading pad = cw/2). -1 when out of range. */
+    function cellAtClientX(clientX: number): number {
+        if (!containerEl) return -1;
+        const rect = containerEl.getBoundingClientRect();
+        const off = clientX - rect.left + offset - cw / 2;
+        return nearestCell(clamp(0, lastRight, off));
+    }
+
+    /** Speculative-prewarm hook on pointer hover (no button): warm the position
+     *  of the cell under the pointer. Suppressed while dragging (the strip owns
+     *  the pointer then). */
+    function onHoverMove(e: PointerEvent): void {
+        if (!onHoverPrewarm || dragging) return;
+        const i = cellAtClientX(e.clientX);
+        if (i >= 0) onHoverPrewarm(cells[i]!.startMs);
     }
 
     /** Re-sync after a seek while paused (parent calls this). */
@@ -284,6 +304,7 @@
         aria-valuemax={cells[cells.length - 1]!.ayah}
         aria-valuenow={activeIdx >= 0 ? cells[activeIdx]!.ayah : cells[0]!.ayah}
         onpointerdown={onPointerDown}
+        onpointermove={onHoverMove}
         onkeydown={(e) => {
             if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
                 e.preventDefault();

--- a/inspector/frontend/src/tabs/timestamps/TimestampsTab.svelte
+++ b/inspector/frontend/src/tabs/timestamps/TimestampsTab.svelte
@@ -432,8 +432,11 @@
     // Ayah-end shuffle boundary: jump to a random target when the playhead reaches
     // the focus verse's end (once per verse). Called from both the rAF tick and the
     // onTimeUpdate/onEnded media-clock backstop; reads the focus verse fresh so the
-    // boundary and the dedupe key never disagree.
+    // boundary and the dedupe key never disagree. Gated to the active Timestamps tab
+    // so the shared dashPort backstop can't hijack Dashboard playback (its own
+    // gapless advance owns dashPort.onEnded when that tab is active).
     function maybeFireShuffle(ms: number): void {
+        if (getActiveTab() !== TAB_NAMES.TIMESTAMPS) return;
         if (get(loopTarget) || !get(shuffleAyah)) return;
         const fv = get(loadedVerse);
         if (!fv) return;

--- a/inspector/frontend/src/tabs/timestamps/TimestampsTab.svelte
+++ b/inspector/frontend/src/tabs/timestamps/TimestampsTab.svelte
@@ -397,7 +397,6 @@
 
     function tick(): void {
         const ms = dashPort.currentTimeMs();
-        const lv = get(loadedVerse);
 
         // rAF seek-back loop (no kill-switch on the shared port; ≤1 frame
         // overshoot). The loop window is computed against the CAPTURED loop
@@ -421,18 +420,28 @@
         }
 
         focusAt(ms);
-
-        // Ayah-end shuffle: when shuffle is on and the playhead reaches the end
-        // of the focus verse, jump to a random target (once per verse).
-        if (!loop && get(shuffleAyah) && lv) {
-            const endMs = lv.tsSegEnd * 1000;
-            if (ms >= endMs - SHUFFLE_END_GUARD_MS && shuffleFiredForRef !== focusRef) {
-                shuffleFiredForRef = focusRef;
-                void shuffleJump();
-                return;
-            }
-        }
+        // rAF gives tight (~16 ms) boundary timing while the tab is active; the
+        // onTimeUpdate/onEnded media-clock backstop (onMount) catches the boundary
+        // when rAF is throttled (backgrounded tab / GC / heavy repaint), where it
+        // would otherwise overshoot by 1-3 words. The once-per-verse guard dedupes
+        // whichever fires first.
+        maybeFireShuffle(ms);
         refreshDisplays();
+    }
+
+    // Ayah-end shuffle boundary: jump to a random target when the playhead reaches
+    // the focus verse's end (once per verse). Called from both the rAF tick and the
+    // onTimeUpdate/onEnded media-clock backstop; reads the focus verse fresh so the
+    // boundary and the dedupe key never disagree.
+    function maybeFireShuffle(ms: number): void {
+        if (get(loopTarget) || !get(shuffleAyah)) return;
+        const fv = get(loadedVerse);
+        if (!fv) return;
+        const endMs = fv.tsSegEnd * 1000;
+        if (ms >= endMs - SHUFFLE_END_GUARD_MS && shuffleFiredForRef !== focusRef) {
+            shuffleFiredForRef = focusRef;
+            void shuffleJump();
+        }
     }
 
     function refreshDisplays(): void {
@@ -816,8 +825,17 @@
                 loopAnchor = null;
             }
         });
+        // Media-clock backstop for the ayah-end shuffle: timeupdate/ended fire off
+        // the audio clock (even when the tab is backgrounded and rAF is throttled),
+        // so the boundary can't overshoot by seconds. Deduped against the rAF tick
+        // by the once-per-verse guard.
+        const offTimeUpdate = dashPort.onTimeUpdate((fileMs) => maybeFireShuffle(fileMs));
+        const offEnded = dashPort.onEnded(() => maybeFireShuffle(Number.POSITIVE_INFINITY));
         _primedOnce = true;
-        return () => { unsubTab(); unsubShuf(); unsubManualShuffle(); unsubLoop(); };
+        return () => {
+            unsubTab(); unsubShuf(); unsubManualShuffle(); unsubLoop();
+            offTimeUpdate(); offEnded();
+        };
     });
 
     onDestroy(() => {

--- a/inspector/frontend/src/tabs/timestamps/components/TimestampsWaveform.svelte
+++ b/inspector/frontend/src/tabs/timestamps/components/TimestampsWaveform.svelte
@@ -96,6 +96,17 @@
     let peaks: PeakBucket[] | Int8Array | null = null;
     let fetchGen = 0;
 
+    // Bucket-snap metadata for the baked-peaks fast path. `_sliceVerseLocal`
+    // snaps the int8 slice to bucket boundaries, so the array covers a span
+    // slightly WIDER than the exact verse window. These describe that slice so
+    // the drawer's density matches the array (peaks line up with overlays):
+    //   _peaksSpanMs   — the slice's true covered duration (drawer totalDurationMs)
+    //   _peaksOriginMs — offset (≥0) from the slice's true start to the exact
+    //                    window start; added to window-relative sub-range ms.
+    // null for the ffmpeg fallback (PeakBucket[] is already verse-exact).
+    let _peaksSpanMs: number | null = null;
+    let _peaksOriginMs = 0;
+
     /** Per-tab LRU keyed by `${url}:${startMs}:${endMs}`. */
     const _peaksLRU = new Map<string, SegmentPeaks>();
 
@@ -154,15 +165,22 @@
     let _zoom: { viewStart: number; viewEnd: number } | null = null;
     $: _zoom = $tsZoom;
 
-    /** Sub-range props forwarded to WaveformCanvas. Both `undefined` → full
-     *  slice (default). When zoomed, `wcStartMs/wcEndMs` are SLICE-relative
-     *  ms (the WaveformCanvas already has full-slice peaks; we just tell it
-     *  which window to render). */
-    $: wcTotalDurationMs = $loadedVerse
-        ? Math.round(($loadedVerse.tsSegEnd - $loadedVerse.tsSegOffset) * 1000)
-        : undefined;
-    $: wcStartMs = _zoom ? Math.round(_zoom.viewStart * 1000) : undefined;
-    $: wcEndMs = _zoom ? Math.round(_zoom.viewEnd * 1000) : undefined;
+    // Sub-range props forwarded to WaveformCanvas, resolved via `_drawRange` so
+    // the bucket-snapped baked slice and the verse-exact ffmpeg slice both map
+    // to the exact-window-relative overlay coords. For the verse-exact path
+    // un-zoomed, all three are `undefined` (drawer renders the full array);
+    // for the baked slice they're always set (window shifted into the slice).
+    // `_peaksSpanMs`/`_peaksOriginMs` are referenced so the reactive re-resolves
+    // when the slice metadata flips (baked ↔ ffmpeg fallback).
+    $: _wcRange = _drawRange(
+        _zoom,
+        $loadedVerse ? ($loadedVerse.tsSegEnd - $loadedVerse.tsSegOffset) * 1000 : 0,
+        _peaksSpanMs,
+        _peaksOriginMs,
+    );
+    $: wcStartMs = _wcRange.startMs;
+    $: wcEndMs = _wcRange.endMs;
+    $: wcTotalDurationMs = _wcRange.totalDurationMs;
 
     // When `tsZoom` changes, the base peak canvas re-renders via WaveformCanvas's
     // reactive on (startMs, endMs, totalDurationMs). We drop the cached
@@ -220,6 +238,8 @@
 
     function _clearPeaks(): void {
         peaks = null;
+        _peaksSpanMs = null;
+        _peaksOriginMs = 0;
         _baseImageData = null;
         _baseCacheKey = null;
     }
@@ -227,23 +247,72 @@
     /** Slice a chapter int8 [min,max] envelope down to a VERSE-LOCAL Int8Array
      *  for the chapter-absolute window [startMs,endMs]. floor(start)/ceil(end)
      *  bucket convention (matches the drawer) so the verse fully covers its
-     *  peaks; the slice may run ≤1 bucket (≤100ms at 10bps) wide of the exact
-     *  window — acceptable per the 10bps decision. Keeping the result
-     *  verse-local means all zoom/overlay/playhead math (slice-relative) stays
-     *  untouched. */
+     *  peaks; the slice runs ≤1 bucket (≤100ms at 10bps) wide of the exact
+     *  window per side.
+     *
+     *  Because of that snap, the slice's TRUE covered span is wider than the
+     *  exact window. We return that span (`spanMs`) and the offset from the
+     *  slice's true start to the exact window start (`originMs` ≥ 0). Draw
+     *  sites feed `spanMs` as the drawer's `totalDurationMs` and add `originMs`
+     *  to the (window-relative) sub-range so the drawer's density matches the
+     *  array — the painted peaks then line up with the boundary/playhead
+     *  overlays instead of drifting by up to one bucket. */
     function _sliceVerseLocal(
         chapterPeaks: Int8Array,
         durationMs: number,
         startMs: number,
         endMs: number,
-    ): Int8Array | null {
+    ): { peaks: Int8Array; spanMs: number; originMs: number } | null {
         const pairs = chapterPeaks.length >> 1;
         if (pairs <= 0 || durationMs <= 0) return null;
         const pairsPerMs = pairs / durationMs;
         const startPair = Math.max(0, Math.floor(startMs * pairsPerMs));
         const endPair = Math.min(pairs, Math.ceil(endMs * pairsPerMs));
         if (endPair <= startPair) return null;
-        return chapterPeaks.slice(startPair * 2, endPair * 2);
+        const trueStartMs = startPair / pairsPerMs;
+        const trueEndMs = endPair / pairsPerMs;
+        return {
+            peaks: chapterPeaks.slice(startPair * 2, endPair * 2),
+            spanMs: trueEndMs - trueStartMs,
+            originMs: startMs - trueStartMs,
+        };
+    }
+
+    /** Resolve the drawer sub-range for the current peaks + zoom. Returns the
+     *  `{ startMs, endMs, totalDurationMs }` to feed `drawWaveformPeaks` so the
+     *  painted peaks align with the (exact-window-relative) overlays.
+     *
+     *  `exactDurationMs` is the exact verse window; the visible window in OVERLAY
+     *  coords (ms from the window start) is `[0, exactDurationMs]` un-zoomed or
+     *  `[viewStart, viewEnd]` zoomed.
+     *
+     *  For the bucket-snapped baked slice (`spanMs` set) the array covers a span
+     *  WIDER than the exact window, so we declare that true span as
+     *  `totalDurationMs` and shift the window by `originMs` into the array. For
+     *  the verse-exact ffmpeg path (`spanMs == null`) the window maps 1:1, with
+     *  an un-zoomed full slice signalled by `undefined` sub-range (drawer renders
+     *  the whole array linearly). */
+    function _drawRange(
+        zoom: { viewStart: number; viewEnd: number } | null,
+        exactDurationMs: number,
+        spanMs: number | null,
+        originMs: number,
+    ): { startMs: number | undefined; endMs: number | undefined; totalDurationMs: number | undefined } {
+        if (spanMs != null) {
+            const winStartMs = zoom ? zoom.viewStart * 1000 : 0;
+            const winEndMs = zoom ? zoom.viewEnd * 1000 : exactDurationMs;
+            return {
+                startMs: Math.round(winStartMs + originMs),
+                endMs: Math.round(winEndMs + originMs),
+                totalDurationMs: Math.round(spanMs),
+            };
+        }
+        // Verse-exact peaks: existing behaviour (undefined sub-range when unzoomed).
+        return {
+            startMs: zoom ? Math.round(zoom.viewStart * 1000) : undefined,
+            endMs: zoom ? Math.round(zoom.viewEnd * 1000) : undefined,
+            totalDurationMs: zoom ? Math.round(exactDurationMs) : undefined,
+        };
     }
 
     async function reactToVerse(
@@ -278,8 +347,10 @@
             const chEntry = chMap ? pickChapterPeaks(chMap, url) : null;
             if (chEntry && chEntry.peaks instanceof Int8Array && chEntry.duration_ms > 0) {
                 const sliced = _sliceVerseLocal(chEntry.peaks, chEntry.duration_ms, startMs, endMs);
-                if (sliced && sliced.length) {
-                    peaks = sliced;
+                if (sliced && sliced.peaks.length) {
+                    peaks = sliced.peaks;
+                    _peaksSpanMs = sliced.spanMs;
+                    _peaksOriginMs = sliced.originMs;
                     _baseImageData = null;
                     _baseCacheKey = null;
                     await tick();
@@ -307,6 +378,9 @@
         }
 
         peaks = entry.peaks;
+        // ffmpeg peaks are verse-exact (no bucket-snap) — use the exact window.
+        _peaksSpanMs = null;
+        _peaksOriginMs = 0;
 
         _baseImageData = null;
         _baseCacheKey = null;
@@ -333,14 +407,14 @@
         // (user-visible as a fixed ghost cursor inside the loop word).
         if (peaks) {
             const lv = get(loadedVerse);
-            const zoom = _zoom;
-            const totalMs = lv ? Math.round((lv.tsSegEnd - lv.tsSegOffset) * 1000) : undefined;
+            const exactMs = lv ? (lv.tsSegEnd - lv.tsSegOffset) * 1000 : 0;
+            const range = _drawRange(_zoom, exactMs, _peaksSpanMs, _peaksOriginMs);
             drawWaveformPeaks(ctx, peaks, {
                 width: canvas.width,
                 height: canvas.height,
-                startMs: zoom ? Math.round(zoom.viewStart * 1000) : undefined,
-                endMs: zoom ? Math.round(zoom.viewEnd * 1000) : undefined,
-                totalDurationMs: totalMs,
+                startMs: range.startMs,
+                endMs: range.endMs,
+                totalDurationMs: range.totalDurationMs,
             });
         }
         _baseImageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
@@ -390,15 +464,13 @@
         if (!animating && _baseImageData && _baseImageData.width === width && _baseImageData.height === height) {
             ctx.putImageData(_baseImageData, 0, 0);
         } else if (peaks) {
-            const zoomMs = _zoom
-                ? { startMs: Math.round(_zoom.viewStart * 1000), endMs: Math.round(_zoom.viewEnd * 1000) }
-                : { startMs: undefined, endMs: undefined };
+            const range = _drawRange(_zoom, duration * 1000, _peaksSpanMs, _peaksOriginMs);
             drawWaveformPeaks(ctx, peaks, {
                 width,
                 height: height,
-                startMs: zoomMs.startMs,
-                endMs: zoomMs.endMs,
-                totalDurationMs: Math.round(duration * 1000),
+                startMs: range.startMs,
+                endMs: range.endMs,
+                totalDurationMs: range.totalDurationMs,
             });
         } else {
             ctx.fillStyle = '#0f0f23';

--- a/inspector/routes/audio/clip.py
+++ b/inspector/routes/audio/clip.py
@@ -29,6 +29,11 @@ CLIP_BITRATE = "96k"
 # Stream stdout to the client in this chunk size. 64 KB keeps TTFB tight
 # while still amortising syscall overhead.
 STREAM_CHUNK_BYTES = 65_536
+# Floor below which the first ffmpeg chunk is treated as a failed extraction
+# rather than a real clip. A deep seek past the real audio of a no-Xing VBR file
+# muxes a header-only MP3 of a few hundred bytes at rc=0; a genuine clip is far
+# larger. Lets us fail loudly (502) instead of streaming decodable-as-silence.
+MIN_VALID_CLIP_BYTES = 1500
 
 
 def _is_known_chapter_url(reciter: str, url: str) -> bool:
@@ -99,8 +104,51 @@ def seg_segment_clip(reciter):
         logger.error("ffmpeg not found on PATH")
         return jsonify({"error": "ffmpeg not available"}), 500
 
+    def _stderr_tail() -> str:
+        try:
+            if proc.stderr and not proc.stderr.closed:
+                return (proc.stderr.read() or b"").decode("utf-8", errors="replace")[-500:]
+        except (OSError, ValueError):
+            pass
+        return ""
+
+    # Peek the first chunk synchronously so a failed extraction fails LOUD (502)
+    # rather than returning a 200 the AudioPort loads as a valid silent window.
+    # ffmpeg that exits having emitted only a header (e.g. a deep seek past the
+    # real audio of a no-Xing VBR file → ~few-hundred-byte mp3 at rc=0) is caught
+    # here; a streaming clip (proc still running) or a genuine short clip passes.
+    try:
+        first = proc.stdout.read(STREAM_CHUNK_BYTES)
+    except (OSError, ValueError):
+        first = b""
+    # A short first read means ffmpeg hit EOF (clip fully produced, or failed) —
+    # reap it so returncode/size are authoritative before judging (poll() races
+    # the EOF). A full chunk means it's still streaming a real clip.
+    if len(first) < STREAM_CHUNK_BYTES:
+        try:
+            proc.wait(timeout=FFMPEG_FULL_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+    exited = proc.poll() is not None
+    if (not first) or (exited and (len(first) < MIN_VALID_CLIP_BYTES or proc.returncode not in (0, None))):
+        stderr_tail = _stderr_tail()
+        if proc.poll() is None:
+            proc.kill()
+        for stream in (proc.stdout, proc.stderr):
+            if stream:
+                stream.close()
+        logger.warning(
+            "segment_clip produced no usable audio: %d bytes (rc=%s) cmd=%s stderr=%r",
+            len(first), proc.returncode, shlex.join(cmd), stderr_tail,
+        )
+        return jsonify({
+            "error": "segment audio unavailable",
+            "detail": "no decodable audio for this window (source likely truncated or corrupt)",
+        }), 502
+
     def _generate():
-        bytes_yielded = 0
+        bytes_yielded = len(first)
+        yield first
         try:
             while True:
                 chunk = proc.stdout.read(STREAM_CHUNK_BYTES)
@@ -114,26 +162,17 @@ def seg_segment_clip(reciter):
                 proc.kill()
                 logger.warning("segment_clip ffmpeg timed out: cmd=%s", shlex.join(cmd))
         finally:
-            # Drain stderr so we can diagnose silent failures (most common:
-            # codec not available in the deployed static ffmpeg → 200/0).
-            stderr_tail = b""
-            try:
-                if proc.stderr and not proc.stderr.closed:
-                    stderr_tail = proc.stderr.read() or b""
-            except (OSError, ValueError):
-                pass
+            stderr_tail = _stderr_tail()
             if proc.stdout:
                 proc.stdout.close()
             if proc.stderr:
                 proc.stderr.close()
             if proc.poll() is None:
                 proc.kill()
-            rc = proc.returncode
-            if bytes_yielded == 0 or (rc is not None and rc != 0):
+            if proc.returncode not in (0, None):
                 logger.warning(
-                    "segment_clip ffmpeg produced %d bytes (rc=%s) cmd=%s stderr=%r",
-                    bytes_yielded, rc, shlex.join(cmd),
-                    stderr_tail.decode("utf-8", errors="replace")[-500:],
+                    "segment_clip ffmpeg exited mid-stream: %d bytes (rc=%s) stderr=%r",
+                    bytes_yielded, proc.returncode, stderr_tail,
                 )
 
     headers = {

--- a/inspector/routes/audio/metadata.py
+++ b/inspector/routes/audio/metadata.py
@@ -4,7 +4,7 @@ import logging
 
 from flask import Blueprint, jsonify
 
-from services import cache, storage_paths
+from services import audio_fetch, cache, storage_paths
 from services.hf_bucket import StorageNotFound, get_backend
 from services.quran_foundation import config as qf_config
 from services.quran_foundation import content as qf_content
@@ -61,6 +61,12 @@ def audio_surahs(category, source, slug):
     show full chapter length before the browser fetches MP3 headers — the
     ``BottomPlayer`` runs ``<audio preload="none">`` and would otherwise
     show ``0:00`` until first play.
+
+    When the sidecar has a null/missing duration for a chapter (e.g. probed
+    before the manifest carried durations), falls back to the duration baked
+    into the slim peaks header (``reciters/<slug>/peaks/<ch>.json.gz``) via
+    ``audio_fetch.read_prefetched_peaks_duration_ms``. Stays ``None`` only
+    when peaks are also absent.
     """
     key = f"{category}/{source}/{slug}"
     cached = cache.get_audio_url_cache(key)
@@ -85,9 +91,16 @@ def audio_surahs(category, source, slug):
                 if isinstance(duration_sec, (int, float))
                 else None
             )
-            surahs[k] = {"url": url, "duration_ms": duration_ms}
         elif isinstance(v, str):
-            surahs[k] = {"url": v, "duration_ms": None}
+            url, duration_ms = v, None
+        else:
+            continue
+        if duration_ms is None:
+            # Manifest never carried a length for this chapter — fall back to
+            # the duration baked into the slim peaks header so the dashboard
+            # scrubber shows a real length instead of 0:00.
+            duration_ms = audio_fetch.read_prefetched_peaks_duration_ms(slug, url)
+        surahs[k] = {"url": url, "duration_ms": duration_ms}
     _apply_qf_routing(source, slug, surahs)
     cache.set_audio_url_cache(key, surahs)
     return jsonify({"surahs": surahs})

--- a/inspector/routes/audio/proxy.py
+++ b/inspector/routes/audio/proxy.py
@@ -94,11 +94,14 @@ def _stream_cdn(url: str, disposition: str | None = None) -> Response:
         logger.warning("audio_proxy: upstream fetch failed url=%s err=%s", url, exc)
         return jsonify({"error": "upstream audio fetch failed"}), 502
 
-    immutable = f"public, max-age={AUDIO_CACHE_MAX_AGE}, immutable"
+    # Cache only successful bodies. A forwarded upstream error (4xx/5xx) must NOT
+    # carry the immutable 1-year Cache-Control, or the browser pins the failure
+    # and replays it until a hard cache clear.
+    ok = upstream.status_code in (200, 206)
     out_headers = {
         "Content-Type": upstream.headers.get("Content-Type", "audio/mpeg"),
         "Accept-Ranges": "bytes",
-        "Cache-Control": immutable,
+        "Cache-Control": f"public, max-age={AUDIO_CACHE_MAX_AGE}, immutable" if ok else "no-store",
         "Access-Control-Allow-Origin": "*",
     }
     if disposition:

--- a/inspector/services/audio/audio_fetch.py
+++ b/inspector/services/audio/audio_fetch.py
@@ -6,8 +6,8 @@ Used by:
 
 No background worker. No CDN downloads. Bucket audio + slim peaks are written by
 the katana extraction pipeline (``.local/extraction/upload_to_bucket.py`` +
-``.local/extraction/segments/audio_persist.py``) and the timestamps job; the
-inspector only reads them — nothing is GC'd.
+``.local/extraction/segments/audio_persist.py``); the inspector only reads them,
+and they persist indefinitely.
 
 No Flask imports — callable from any thread.
 """

--- a/inspector/services/audio/audio_fetch.py
+++ b/inspector/services/audio/audio_fetch.py
@@ -96,3 +96,20 @@ def read_prefetched_peaks(slug: str, url: str) -> dict | None:
     except Exception:  # noqa: BLE001
         return None
     return unpack_slim_envelope(blob)
+
+
+def read_prefetched_peaks_duration_ms(slug: str, url: str) -> int | None:
+    """Return just the chapter ``duration_ms`` from the slim peaks header.
+
+    Fallback length source for the dashboard player when the audio_manifest
+    sidecar has a null/missing ``duration_sec`` (e.g. a reciter probed before
+    the manifest carried durations). Reads the slim envelope header — the same
+    ``duration_ms`` baked alongside the peaks at extraction time — without
+    decoding the int8 payload. Returns ``None`` when peaks are also absent,
+    the URL is unknown, or the blob is corrupt.
+    """
+    env = read_prefetched_peaks(slug, url)
+    if env is None:
+        return None
+    dur = env.get("duration_ms")
+    return int(dur) if isinstance(dur, (int, float)) and dur > 0 else None

--- a/inspector/services/audio/audio_meta.py
+++ b/inspector/services/audio/audio_meta.py
@@ -9,7 +9,8 @@ Keys are ``"1"``…``"114"`` for by_surah deliveries and ``"<surah>:<ayah>"``
 for by_ayah. The sidecar is written by the offline probe
 (``scripts/probe_audio_meta.py``) and is the single source of truth for both
 VBR routing decisions and the chapter→URL reverse lookup that powers the
-audio-proxy short-circuit + prefetch queue enumeration.
+audio-proxy short-circuit, the segment-clip allowlist, and the peaks route's
+chapter→URL enumeration.
 
 No Flask imports — pure data access.
 """
@@ -171,8 +172,8 @@ def chapter_for_url(reciter: str, url: str) -> str | None:
 
 
 def chapter_urls(reciter: str) -> dict[str, str]:
-    """Full chapter-key → URL map. Used by the prefetch queue to enumerate
-    work. Empty dict when the sidecar is missing.
+    """Full chapter-key → URL map. Drives the ``/peaks`` route's chapter→URL
+    enumeration. Empty dict when the sidecar is missing.
     """
     out: dict[str, str] = {}
     for k, entry in _chapters(reciter).items():

--- a/inspector/services/audio/audio_source.py
+++ b/inspector/services/audio/audio_source.py
@@ -2,8 +2,8 @@
 
 Every consumer that needs audio bytes — the audio-proxy route, peaks decode,
 auto_split slicing — goes through here. The resolver answers: "where do this
-chapter's bytes live right now (bucket prefetch, disk cache, or only at the
-CDN)?" and "is this chapter VBR?", reading both signals from the per-slug
+chapter's bytes live right now (a local bucket file, in-memory bucket bytes,
+or only at the CDN)?" and "is this chapter VBR?", reading both signals from the per-slug
 audio_manifest sidecar in the bucket (single source of truth).
 
 No Flask. No I/O beyond what ``audio_fetch`` and ``cache`` already do.

--- a/inspector/tests/test_audio_source.py
+++ b/inspector/tests/test_audio_source.py
@@ -86,3 +86,53 @@ def test_unknown_url_yields_blank_metadata(stub_env):
     assert src.vbr is False
     assert src.bitrate_kbps is None
     assert src.chapter_key is None
+
+
+# ---------------------------------------------------------------------------
+# read_prefetched_peaks_duration_ms — slim-header fallback length source
+# ---------------------------------------------------------------------------
+
+
+def _packed_envelope(duration_ms: int) -> bytes:
+    """A minimal valid slim peaks blob carrying ``duration_ms`` in its header."""
+    from services.audio.peaks_slim import pack_slim
+
+    return pack_slim({"schema_version": 2, "duration_ms": duration_ms,
+                      "peaks": [[-0.5, 0.5]] * 30})
+
+
+def test_peaks_duration_ms_reads_header(monkeypatch):
+    from services import audio_fetch, audio_meta
+    from services.audio import audio_fetch as af_mod
+
+    audio_meta._clear_for_test()
+    audio_meta._stage_for_test("rec", {
+        "chapters": {"1": {"url": "https://cdn/1.mp3"}},
+    })
+    backend = type("B", (), {"read_bytes": staticmethod(
+        lambda path: _packed_envelope(47000))})()
+    monkeypatch.setattr(af_mod, "get_backend", lambda: backend)
+
+    assert audio_fetch.read_prefetched_peaks_duration_ms("rec", "https://cdn/1.mp3") == 47000
+    audio_meta._clear_for_test()
+
+
+def test_peaks_duration_ms_none_when_peaks_absent(monkeypatch):
+    from services import audio_fetch, audio_meta
+    from services.audio import audio_fetch as af_mod
+
+    audio_meta._clear_for_test()
+    audio_meta._stage_for_test("rec", {
+        "chapters": {"1": {"url": "https://cdn/1.mp3"}},
+    })
+
+    def _missing(path):
+        raise FileNotFoundError(path)
+
+    backend = type("B", (), {"read_bytes": staticmethod(_missing)})()
+    monkeypatch.setattr(af_mod, "get_backend", lambda: backend)
+
+    assert audio_fetch.read_prefetched_peaks_duration_ms("rec", "https://cdn/1.mp3") is None
+    # Unknown URL → None without touching the backend.
+    assert audio_fetch.read_prefetched_peaks_duration_ms("rec", "https://cdn/zzz.mp3") is None
+    audio_meta._clear_for_test()

--- a/inspector/tests/test_qf_content_audio.py
+++ b/inspector/tests/test_qf_content_audio.py
@@ -178,3 +178,70 @@ def test_route_falls_back_on_api_error(flask_client, monkeypatch):
     surahs = resp.get_json()["surahs"]
     assert surahs["1"]["via"] == "qf_fallback"
     assert surahs["1"]["url"].endswith("/quran/x/001.mp3")  # our link retained
+
+
+# ---- peaks duration fallback (null manifest duration) ----
+
+
+def _stub_null_duration_manifest(monkeypatch, *, peaks_durations):
+    """Stage a non-QF manifest where every chapter has a null ``duration_sec``,
+    and stub the slim-peaks duration reader with ``peaks_durations`` keyed by
+    URL. QF routing is disabled so the route returns the raw manifest shape.
+    """
+    from routes.audio import metadata
+    from services.storage import cache
+
+    cache._audio_url.clear()
+
+    backend = types.SimpleNamespace(
+        read_json=lambda path: {
+            "chapters": {
+                "1": {"url": "https://cdn/x/001.mp3"},  # no duration_sec
+                "2": {"url": "https://cdn/x/002.mp3", "duration_sec": None},
+            }
+        }
+    )
+    monkeypatch.setattr(metadata, "get_backend", lambda: backend)
+    monkeypatch.setattr(metadata.qf_config, "content_is_configured", lambda: False)
+    monkeypatch.setattr(
+        metadata.audio_fetch,
+        "read_prefetched_peaks_duration_ms",
+        lambda slug, url: peaks_durations.get(url),
+    )
+
+
+def test_route_fills_null_duration_from_peaks_header(flask_client, monkeypatch):
+    _stub_null_duration_manifest(
+        monkeypatch,
+        peaks_durations={"https://cdn/x/001.mp3": 47000},  # ch2 peaks absent
+    )
+    resp = flask_client.get("/api/audio/surahs/by_surah/mp3quran/some_slug")
+    assert resp.status_code == 200
+    surahs = resp.get_json()["surahs"]
+    # ch1 had no duration_sec → filled from peaks header.
+    assert surahs["1"]["duration_ms"] == 47000
+    # ch2 had null duration_sec AND no peaks → stays None.
+    assert surahs["2"]["duration_ms"] is None
+
+
+def test_route_keeps_manifest_duration_when_present(flask_client, monkeypatch):
+    from routes.audio import metadata
+    from services.storage import cache
+
+    cache._audio_url.clear()
+    backend = types.SimpleNamespace(
+        read_json=lambda path: {
+            "chapters": {"1": {"url": "https://cdn/x/001.mp3", "duration_sec": 90}}
+        }
+    )
+    monkeypatch.setattr(metadata, "get_backend", lambda: backend)
+    monkeypatch.setattr(metadata.qf_config, "content_is_configured", lambda: False)
+    # If the manifest duration is present the peaks reader must NOT be consulted.
+    monkeypatch.setattr(
+        metadata.audio_fetch,
+        "read_prefetched_peaks_duration_ms",
+        lambda slug, url: pytest.fail("peaks fallback should not run"),
+    )
+    resp = flask_client.get("/api/audio/surahs/by_surah/mp3quran/some_slug")
+    surahs = resp.get_json()["surahs"]
+    assert surahs["1"]["duration_ms"] == 90000


### PR DESCRIPTION
## Summary

A round of audio improvements from an audit of the playback path — the dashboard player, the timestamps waveform, and the backend audio routes. The goal was to make playback feel faster and more reliable, and to turn a couple of silent failure modes into visible ones.

## Dashboard player

- **Faster starts and gapless hand-off.** The player now warms the next chapter ahead of likely actions — hovering the next/previous-surah controls, opening the surah list, hovering the progress bar, or nearing the end of the current surah — so playback starts (and rolls into the next chapter) without the usual cold-start pause.
- **Honest loading state.** The spinner now clears when audio actually starts rather than when the file finishes downloading. Before, it could stop a beat early and leave a second or two of silence before sound; that gap is gone.
- Picking a chapter without hitting play warms it quietly in the background, so the eventual play is instant.

A behavior note worth calling out: the dashboard now advances to the next chapter automatically when one ends — that's what makes the gapless hand-off meaningful. It's a small, easily reverted change if we'd rather each surah stop at the end.

## Timestamps

- **Waveform alignment.** On short verses the painted waveform could sit slightly off from the verse boundaries and the playhead. It's now drawn against the exact window it covers, so the wave lines up with the markers.
- Hardened the ayah-shuffle hand-off so it can't overshoot into the next verse when the browser tab is backgrounded, and so it never fires while you're on the dashboard.

## Backend audio

- **Segment clips fail loudly.** A deep seek that produced no decodable audio used to return a valid-looking but empty file, so playback was just silent. It now returns a clear error, and those bad responses are no longer cached.
- **Scrubber duration fallback.** Some reciters ship without a duration in their manifest, which left the scrubber at 0:00 until the first play. The duration is now read from the waveform sidecar as a fallback, so it's correct up front.

## Testing

- Frontend type-check and unit tests pass; backend audio tests pass, with new coverage for the duration fallback and the clip-failure path.
- Spot-checked live: cold-start playback, hover-to-prewarm of the next surah, and the loading state.

## Follow-up (not in this PR)

A small data backfill for two reciters (a missing manifest duration and one chapter with a corrupt tail) touches the production bucket, so it's deferred to be done deliberately with a restart — the in-app duration fallback above already covers the visible symptom in the meantime.
