### PR TITLE
fix(ts): verse clip bounds cover all word/letter times (containment)

### DIFF
--- a/inspector/frontend/src/lib/recitation-data/occasion-dedup.ts
+++ b/inspector/frontend/src/lib/recitation-data/occasion-dedup.ts
@@ -141,7 +141,10 @@ export function groupVerseOccasions(segments: SegmentEntry[]): VerseOccasions[] 
 /**
  * Flatten a canonical occasion into the words the per-verse clip renders.
  * Trailing post-completion segments are trimmed (never cut mid-audio); the
- * returned `[startMs, endMs]` span covers the kept segments.
+ * returned `[startMs, endMs]` span covers every kept segment AND every
+ * word/letter time. A word/letter can bleed a few ms past its segment's `t`
+ * bound, so the clip must reach the furthest word/letter end or it would
+ * truncate the final word's tail (mirrors the backend `_canonical_verse`).
  */
 export function canonicalClip(
     occasion: Occasion,
@@ -155,9 +158,20 @@ export function canonicalClip(
     const words: SegmentEntry['words'] = [];
     for (const seg of kept) words.push(...seg.words);
 
-    const startMs = kept[0]?.t[0] ?? 0;
+    let startMs = kept[0]?.t[0] ?? 0;
     let endMs = kept[0]?.t[1] ?? 0;
-    for (const seg of kept) if (seg.t[1] > endMs) endMs = seg.t[1];
+    for (const seg of kept) {
+        if (seg.t[0] < startMs) startMs = seg.t[0];
+        if (seg.t[1] > endMs) endMs = seg.t[1];
+        for (const w of seg.words) {
+            if (w[1] < startMs) startMs = w[1];
+            if (w[2] > endMs) endMs = w[2];
+            for (const lt of w[3] ?? []) {
+                if (lt[1] != null && lt[1] < startMs) startMs = lt[1];
+                if (lt[2] != null && lt[2] > endMs) endMs = lt[2];
+            }
+        }
+    }
     return { words, startMs, endMs };
 }
 

--- a/inspector/tests/services/test_ts_roundtrip.py
+++ b/inspector/tests/services/test_ts_roundtrip.py
@@ -35,10 +35,14 @@ CAT = "by_surah_audio"
 SLUG = "roundtrip_reciter"
 
 
-def _ok(locations, t0=0.0, step=0.5):
+def _ok(locations, t0=0.0, step=0.2):
+    # Segment-RELATIVE word times (s): the pipeline's _convert_word adds the
+    # segment's time_start offset downstream, so words land inside the segment.
+    # t0 is accepted for call-site readability but unused (passing the segment
+    # start here would double-count the offset); step keeps words within span.
     words = []
     for i, loc in enumerate(locations):
-        s = t0 + i * step
+        s = i * step
         words.append({
             "location": loc, "start": s, "end": s + step,
             "letters": [{"char": "x", "start": s, "end": s + step}],

--- a/qua_shared/tests/test_segment_shard_dedup.py
+++ b/qua_shared/tests/test_segment_shard_dedup.py
@@ -160,3 +160,23 @@ def test_by_ayah_ref_projection():
     shard = _shard([_seg("2:255", 0, 4000, [1, 2, 3])])
     out = project_segment_shard(shard)
     assert _widxs(out["2:255"]) == [1, 2, 3]
+
+
+# --- verse bounds are a superset of every word/letter time (no clip truncation) ---
+
+def test_verse_bounds_cover_word_and_letter_bleed():
+    # A word (and its last letter) can end a few ms PAST the segment's t[1]; the
+    # clip bound must reach them, not stop at the segment edge, or the final word
+    # gets truncated and a word end falls outside [verse_start, verse_end].
+    seg = {"ref": "1:1", "t": [0, 1000], "words": [
+        [1, 0, 500, [["a", 0, 500]], []],
+        # word 2 ends 5 ms past seg.t[1]=1000; its last letter ends at 1007.
+        [2, 500, 1005, [["b", 500, 1007]], []],
+    ]}
+    v = project_segment_shard(_shard([seg]))["1:1"]
+    assert v["verse_end_ms"] == 1007 and v["verse_start_ms"] == 0, v
+    # Invariant: every word + letter time lies within [verse_start, verse_end].
+    for w in v["words"]:
+        assert v["verse_start_ms"] <= w[1] and w[2] <= v["verse_end_ms"]
+        for _ch, ls, le in w[3]:
+            assert v["verse_start_ms"] <= ls and le <= v["verse_end_ms"]

--- a/qua_shared/tests/test_timestamps_dedup.py
+++ b/qua_shared/tests/test_timestamps_dedup.py
@@ -47,11 +47,19 @@ from qua_shared.timestamps_shards import (  # noqa: E402
 CAT = "by_surah_audio"
 
 
-def _ok(locations, t0=0.0, step=0.5):
-    """Synthetic MFA 'ok' result: one word per location, sequential times (s)."""
+def _ok(locations, t0=0.0, step=0.2):
+    """Synthetic MFA 'ok' result: one word per location, SEGMENT-RELATIVE times (s).
+
+    Word times start at 0 within the segment; the pipeline's ``_convert_word``
+    adds the segment's ``time_start`` offset downstream, so the words land inside
+    ``[seg.time_start, seg.time_end]`` (as in real extraction). ``t0`` is accepted
+    for call-site readability but unused — passing the segment's start here would
+    double-count the offset. ``step`` is small enough that every fixture's words
+    fit within its segment span.
+    """
     words = []
     for i, loc in enumerate(locations):
-        s = t0 + i * step
+        s = i * step
         words.append({
             "location": loc, "start": s, "end": s + step,
             "letters": [{"char": "x", "start": s, "end": s + step}],

--- a/qua_shared/timestamps_dedup.py
+++ b/qua_shared/timestamps_dedup.py
@@ -185,15 +185,26 @@ def _canonical_verse(words: list, segs: list[dict]) -> dict:
     """Assemble the canonical verse-map value from the chosen occasion's words.
 
     Concatenates the accumulated word lists (recitation order, loops retained)
-    and stamps ``verse_start_ms`` / ``verse_end_ms`` from the segment span so
-    downstream tier/dataset builders get the clip boundary for free.
+    and stamps ``verse_start_ms`` / ``verse_end_ms`` as the span covering every
+    kept segment AND every word/letter time. A word or letter can bleed a few ms
+    past its segment's ``t`` bound, so the clip must reach the furthest word/letter
+    end or it would truncate the final word's tail (and verse_end < a word's end
+    violates the "all times within [verse_start, verse_end]" invariant).
     """
-    verse_start = segs[0]["t"][0]
-    verse_end = max(int(s["t"][1]) for s in segs)
+    starts = [int(s["t"][0]) for s in segs]
+    ends = [int(s["t"][1]) for s in segs]
+    for w in words:
+        starts.append(int(w[1]))
+        ends.append(int(w[2]))
+        for lt in (w[3] if len(w) > 3 else []):
+            if lt[1] is not None:
+                starts.append(int(lt[1]))
+            if lt[2] is not None:
+                ends.append(int(lt[2]))
     return {
         "words": words,
-        "verse_start_ms": int(verse_start),
-        "verse_end_ms": int(verse_end),
+        "verse_start_ms": min(starts),
+        "verse_end_ms": max(ends),
     }
 
 


### PR DESCRIPTION
## What

Follow-up to #127. An independent verifier of the segment-array dedup found that the canonical **verse clip bound** (`verse_end_ms`) was computed from the **segment** edge only (`max(seg.t[1])`), while a word — or its last letter — can bleed a few ms past its segment. So on real data the last word/letter ended **past `verse_end`**, i.e. word/letter times fell **outside** `[verse_start, verse_end]` and the clip truncated the final word's tail by ≤5 ms.

Containment check across all 11 published reciters (68,570 verses):

```
coverage gaps (missing words):           0     (full coverage already holds)
word START < verse_start:                0
word END   > verse_end:             10,070     ≤5 ms   ← this bug
letter END > verse_end:             10,249     ≤5 ms
```

## Fix

`qua_shared/timestamps_dedup.py::_canonical_verse` and the FE mirror `occasion-dedup.ts::canonicalClip` now set `verse_start`/`verse_end` as the **superset of every kept segment AND every word/letter span** — the clip is guaranteed to contain all the times it carries. `verse_start` is unchanged in practice (0 start violations); only `verse_end` extends to reach a bleeding final word/letter. **Code-only, no bucket change** — the bucket stores raw segments; the bound is *derived* at job/display time, so this propagates on deploy.

Inaudible in itself (≤5 ms, sub-frame), but it's a real containment-invariant violation and restores parity with the pre-refactor pipeline (which used `max(word_end)`). No new release/dataset has been cut by the new pipeline yet, so the tight bound never reached a published artifact.

## Tests

- New `test_verse_bounds_cover_word_and_letter_bleed` asserts `verse_end` reaches the furthest word/letter end and that every word/letter time lies within `[verse_start, verse_end]`.
- Fixed the synthetic roundtrip `_ok` fixtures (both `qua_shared` and inspector): they passed `t0` equal to the segment start while the pipeline's `_convert_word` *also* adds the segment offset, double-counting so words landed far past their segment. Made them segment-relative (as in real extraction) so word times sit inside their segment.
- Green: `qua_shared` 47, inspector ts subset 991, `svelte-check` 0/0.