### PR TITLE
Audio: raise YouTube canonical encode to 192k CBR

### DIFF
--- a/.claude/skills/inspector-audio/references/extraction-intake.md
+++ b/.claude/skills/inspector-audio/references/extraction-intake.md
@@ -48,8 +48,10 @@ was removed; content persists indefinitely). See `prefetch.md`.
 Every other source preserves the publisher's mp3 bytes verbatim and only injects
 a Xing seek header (`-c:a copy`). A YouTube/playlist source is the exception:
 the source is opus/m4a, so `segments/audio_io.py::_download_via_ytdlp` fetches
-`bestaudio` and does ONE controlled encode → **128 kbps CBR / 44.1 kHz / mono**,
+`bestaudio` and does ONE controlled encode → **192 kbps CBR / 44.1 kHz / mono**,
 `-vn` (cover-art stripped — an APIC stream 0-byte-muxes on the static ffmpeg).
+192k: `bestaudio` is opus ~130–160 kbps and opus is ~1.4× more bit-efficient than
+mp3, so 192k CBR preserves it transparently; mono since recitation is single-voice.
 The watch URL can't be HTTP-frame-probed, so the audio-manifest sidecar + the
 delivery rollup are authored from a **post-align reprobe** of the produced files
 (`ingest_intake.py::reprobe_persisted_audio`), not from the source URL. These

--- a/.claude/skills/inspector-audio/references/vbr.md
+++ b/.claude/skills/inspector-audio/references/vbr.md
@@ -126,7 +126,7 @@ The HF dataset (`.github/scripts/build_reciter.py`) slices per-ayah audio out of
 
 VBR mitigations should live in either Xing-injection (extraction-time, on Katana) or segment-clip (request-time). Don't add a third path — adding a "fix in the AudioPort" is debt; adding a "let the frontend probe encoding mode" duplicates the sidecar.
 
-YouTube / yt-dlp sources sidestep this entirely: extraction re-encodes them to **forced CBR** (128k / 44.1k / mono — see `extraction-intake.md`), so they never carry the VBR-without-Xing drift the mitigations above exist for.
+YouTube / yt-dlp sources sidestep this entirely: extraction re-encodes them to **forced CBR** (192k / 44.1k / mono — see `extraction-intake.md`), so they never carry the VBR-without-Xing drift the mitigations above exist for.
 
 If a new bug class shows up, prefer:
 

--- a/docs/reference/catalog.md
+++ b/docs/reference/catalog.md
@@ -235,7 +235,7 @@ Row-level `bitrate_mode` (`BitrateMode` enum) derived from per-chapter probe dat
 
 Detection: `mutagen.mp3.MP3.info.bitrate_mode` (Xing/Info/VBRI/LAME header) authoritative; frame scan over first 256 KB as fallback. Both run; per-chapter results land in the sidecar, rolled up to the row at build.
 
-**Download-only sources create their own encode.** Unlike CDN audio (publisher mp3 bytes preserved verbatim, with only a Xing seek header injected via `-c:a copy`), a YouTube/yt-dlp source is opus/m4a — so extraction produces the canonical mp3 once: **128 kbps CBR, 44.1 kHz, mono**, cover-art stripped (`segments/audio_io.py::_download_via_ytdlp`). Because the watch URL can't be HTTP-frame-probed, the row + sidecar audio fields come from a **post-align reprobe** of the produced files (`ingest_intake.py::reprobe_persisted_audio`). Forced-CBR ⇒ these deliveries never hit the VBR playback path.
+**Download-only sources create their own encode.** Unlike CDN audio (publisher mp3 bytes preserved verbatim, with only a Xing seek header injected via `-c:a copy`), a YouTube/yt-dlp source is opus/m4a — so extraction produces the canonical mp3 once: **192 kbps CBR, 44.1 kHz, mono**, cover-art stripped (`segments/audio_io.py::_download_via_ytdlp`). Because the watch URL can't be HTTP-frame-probed, the row + sidecar audio fields come from a **post-align reprobe** of the produced files (`ingest_intake.py::reprobe_persisted_audio`). Forced-CBR ⇒ these deliveries never hit the VBR playback path.
 
 ### Style vs recording_context
 

--- a/inspector/tests/services/test_intake_ingest.py
+++ b/inspector/tests/services/test_intake_ingest.py
@@ -174,7 +174,7 @@ def test_ingest_new_reciter_creates_reciter_and_vocab(fs_backend):
 def test_ingest_youtube_delivery_carries_source_url_and_rollup(fs_backend):
     """A YouTube intake: channel=youtube (auto-added via vocab_additions), a
     per-uploader source, the originating playlist URL persisted as
-    Delivery.source_url, and the post-align reprobe rollup (cbr / 128 / 44100 /
+    Delivery.source_url, and the post-align reprobe rollup (cbr / 192 / 44100 /
     total duration) landing on the delivery row."""
     rid = _seed_accepted_intake(kind="new_reciter", reciter_id="yt_reciter")
     body = {
@@ -185,7 +185,7 @@ def test_ingest_youtube_delivery_carries_source_url_and_rollup(fs_backend):
             "source_url": "https://www.youtube.com/playlist?list=PLxyz",
             "audio_category": "by_surah", "recording_year": None,
             "recording_context": None,
-            "bitrate_mode": "cbr", "bitrate_kbps_nominal": 128,
+            "bitrate_mode": "cbr", "bitrate_kbps_nominal": 192,
             "sample_rate_hz": 44100, "total_duration_sec": 3600,
         },
         "vocab_additions": {
@@ -205,7 +205,7 @@ def test_ingest_youtube_delivery_carries_source_url_and_rollup(fs_backend):
     assert d.channel == "youtube" and d.source == "some_uploader"
     assert d.source_url == "https://www.youtube.com/playlist?list=PLxyz"
     assert d.bitrate_mode.value == "cbr"
-    assert d.bitrate_kbps_nominal == 128
+    assert d.bitrate_kbps_nominal == 192
     assert d.sample_rate_hz == 44100
     assert d.total_duration_sec == 3600
 


### PR DESCRIPTION
## Summary

Follow-up to #128 (YouTube as a first-class audio source). Raises the canonical encode for YouTube / yt-dlp sources from **128k → 192k CBR** (mono and 44.1 kHz unchanged).

## Why

A YouTube source has no publisher mp3 to preserve — extraction *creates* the canonical bucket bytes once, with no higher-quality master retained, so the encode bitrate is a permanent fidelity ceiling. 128k was the most lossy tier for a write-once file.

Grounded in a probe of a real 114-video full-mushaf playlist: every video's `bestaudio` came back opus, 48 kHz, ~133–150 kbps (median 145) — completely uniform. Opus is ~1.4× more bit-efficient than mp3, so ~145k opus is perceptually ≈ mp3 ~200k. **192k CBR preserves that transparently; 128k parked the canonical below the source.** 256k is diminishing returns for single-voice recitation, so 192k is the sweet spot. CBR + mono are kept as-is (mono = single voice; forced CBR keeps these deliveries off the VBR playback path).

## What's in this diff (the committed half)

- The canonical-encode convention in the three reference docs (`extraction-intake.md`, `vbr.md`, `catalog.md`).
- The YouTube ingest test's expected rollup (128 → 192).

## Not in this diff (offline, deploys to Katana)

The actual encoder constant `_CANON_MP3_BITRATE` lives in `.local/extraction/segments/audio_io.py` (`_download_via_ytdlp`) — gitignored, ships to Katana via `sync_mfa.sh`. It's set to `"192k"` alongside this PR but isn't a tracked file, mirroring how #128 split its committed and offline halves.

## Scope / impact

- Affects **future** YouTube ingests only — no existing bucket audio is re-encoded. A YouTube reciter already ingested at 128k would need a re-ingest to pick up 192k (per #128's verification notes, none seeded yet).
- Metadata handling is unchanged and already clean: the source carries no meaningful tags, the encode strips cover-art via `-vn`, and the muxer writes the Info/duration header.

## Verification

`test_intake_ingest.py` — 10 passed.
