### PR TITLE
fix(ci): grant deploy workflow pull-requests:write so it stops failing at startup

### DIFF
--- a/.github/workflows/inspector-deploy.yml
+++ b/.github/workflows/inspector-deploy.yml
@@ -27,11 +27,14 @@ on:
         default: false
 
 # Deploy only checks out and uploads to the HF Space — it never writes back to
-# the repo. The reusable inspector-checks.yml frontend-checks job no longer
-# pushes autofixes (it surfaces them as PR suggestions instead), and this
-# workflow runs only on push/dispatch (never pull_request), so read is enough.
+# the repo. But it calls the reusable inspector-checks.yml, whose frontend-checks
+# job declares `pull-requests: write` (for reviewdog PR suggestions). A reusable
+# job cannot request more than the caller grants, so the caller must grant it too
+# or the run fails at startup — even though reviewdog's step is skipped on push.
+# Mirrors docker-publish.yml (the other caller).
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   # Avoid two pushes deploying simultaneously — the Hub upload is idempotent


### PR DESCRIPTION
## Why

The #137 merge to `main` **never deployed to the prod Space** — the `Deploy Inspector` run for the merge commit (`cf60d90b`) ended in **`startup_failure`** (no `checks`, no upload).

Root cause is a reusable-workflow permissions mismatch introduced in #135:

- `inspector-deploy.yml` was tightened to top-level `permissions: contents: read`.
- `inspector-checks.yml`'s `frontend-checks` job (called by deploy) declares `pull-requests: write` (for the reviewdog suggester).
- A reusable job **cannot request more permission than the caller grants**, so GitHub rejects the whole run at startup.

#135 correctly added `pull-requests: write` to the *other* caller (`docker-publish.yml`) but missed `inspector-deploy.yml`.

It worked before #135 because deploy then had `contents: write` (broad enough); #135's `contents: read` tightening is what exposed it. It also passes on PRs because the PR-trigger caller grants PR-write.

## Fix

Mirror `docker-publish.yml`: grant the deploy workflow `pull-requests: write`. The reviewdog step is `if: github.event_name == 'pull_request'`, so it never runs on a deploy push — the permission just has to be *grantable* to satisfy the reusable-workflow cap.

## Effect

Merging this pushes to `main` and touches `inspector-deploy.yml` (in the deploy path filter), so it triggers a deploy run that should now start cleanly, run `checks`, and upload the merged `#137` code to the **prod** Space (`main → prod`).

https://claude.ai/code/session_01N8weCs4TytWGXpcGn7YZo7

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8weCs4TytWGXpcGn7YZo7)_