### PR TITLE
fix(ts-fe): timestamps shuffle button icon lag

### DIFF
--- a/inspector/frontend/src/tabs/timestamps/components/TimestampsFooterLeft.svelte
+++ b/inspector/frontend/src/tabs/timestamps/components/TimestampsFooterLeft.svelte
@@ -33,7 +33,6 @@
     // reciter + ayah). Off/ayah share the single-reciter glyph (ayah just
     // highlights it); both swaps to the random-reciter glyph.
     const SHUFFLE_LABEL = ['Shuffle: off', 'Shuffle ayah (same reciter)', 'Shuffle reciter + ayah'];
-    const shuffleSrc = $derived($shuffleMode === 2 ? '/icons/reciter_random.svg' : '/icons/reciter.svg');
 
     let manifestSlugs = $state(new Set<string>());
     let pickerOpen = $state(false);
@@ -164,7 +163,18 @@
         type="button" class="shuffle-btn" class:on={$shuffleMode !== 0}
         aria-label={SHUFFLE_LABEL[$shuffleMode]} title={SHUFFLE_LABEL[$shuffleMode]}
         onclick={onShuffleClick}
-    ><img class="shuffle-img" src={shuffleSrc} alt="" aria-hidden="true" /></button>
+    ><span class="shuffle-imgs">
+            <!-- Both glyphs render once (decoded at mount); the cycle only flips
+                 which is visible via CSS — no src swap, so no per-toggle decode. -->
+            <img
+                class="shuffle-img" class:active={$shuffleMode !== 2}
+                src="/icons/reciter.svg" alt="" aria-hidden="true"
+            />
+            <img
+                class="shuffle-img" class:active={$shuffleMode === 2}
+                src="/icons/reciter_random.svg" alt="" aria-hidden="true"
+            />
+        </span></button>
 </div>
 
 <style>
@@ -191,14 +201,25 @@
     }
     .shuffle-btn:hover { color: var(--text-primary); border-color: var(--border-strong); background: var(--panel); }
     .shuffle-btn.on { color: var(--accent); background: var(--accent-tint); border-color: var(--accent); }
-    .shuffle-img {
+    /* Wrapper carries the emphasis opacity (off/hover/on); each glyph toggles
+       its own opacity instantly so the swap never re-decodes or re-fetches. */
+    .shuffle-imgs {
+        position: relative;
         width: 18px;
         height: 18px;
         opacity: 0.6;
         transition: opacity var(--t-fast);
     }
-    .shuffle-btn:hover .shuffle-img { opacity: 0.9; }
-    .shuffle-btn.on .shuffle-img { opacity: 1; }
+    .shuffle-btn:hover .shuffle-imgs { opacity: 0.9; }
+    .shuffle-btn.on .shuffle-imgs { opacity: 1; }
+    .shuffle-img {
+        position: absolute;
+        inset: 0;
+        width: 18px;
+        height: 18px;
+        opacity: 0;
+    }
+    .shuffle-img.active { opacity: 1; }
 
     .picker-wrap { position: relative; min-width: 0; }
     .picker-trigger {


### PR DESCRIPTION
## Problem

In the Timestamps tab audio player footer, the tri-state shuffle button's icon took a visible moment to update when toggling to/from the random-reciter state. The lag happened on **every** toggle that changed the glyph, and **independent of whether audio was playing** — which ruled out any coupling to the audio/playback path.

## Root cause

Not the audio pipeline, and not a blocked main thread. The icon was a single `<img>` whose `src` was swapped between `reciter.svg` and `reciter_random.svg`:

```js
const shuffleSrc = $derived($shuffleMode === 2 ? '/icons/reciter_random.svg' : '/icons/reciter.svg');
```

Changing an `<img>`'s `src` doesn't repaint the new glyph synchronously — the browser runs its async **decode** pipeline and swaps the pixels a frame or more later. With no `decoding="sync"` / prior `img.decode()`, that late swap recurs on every real `src` change (caching the bytes doesn't cache the decoded swap), and is completely independent of audio state.

This was confirmed against the symptom: the off→ayah step (which keeps the *same* glyph and only changes a highlight) was instant, while the two steps that actually swap the glyph lagged.

## Fix

Stop swapping `src`. Both glyphs are now rendered once and decoded at mount; the cycle flips which one is visible via CSS opacity. The wrapper carries the off/hover/on emphasis opacity, and each glyph toggles its own opacity instantly — no per-click fetch or decode. This also permanently eliminates the original cold-fetch of `reciter_random.svg` on first reaching the random-reciter state.

## Verification

- `npm run check` — 0 errors, 0 warnings
- `npm run lint` — clean

Diagnosis-only investigation found no heavy synchronous work in the toggle path (no audio-graph rebuild, no peaks/waveform recompute, no big loop/parse), confirming the render-pipeline decode was the cause.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZqPU8ASubc3quNds5Kcik)_