### PR TITLE
Recitation-driven ayah filmstrip (silence-freeze + loopbacks)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,11 @@ Can access from `HF_TOKEN` in `.env`
 
 ## Commands
 
+**First-time setup (fresh checkout / ephemeral container): run `scripts/devenv/setup.sh`** to install FE (`npm ci`) + BE (`pip`) deps before running tests/build — then use the pinned `npm run *` scripts below, never `npx`/`npm exec` (they can pull a mismatched vitest).
+
 | Task | Command |
 |---|---|
+| First-time setup (FE + BE deps) | `scripts/devenv/setup.sh` (`frontend` / `backend` to scope) |
 | Build frontend | `cd frontend && npm install && npm run build` |
 | Run server (dev) | `python3 inspector/app.py` → http://localhost:5000 |
 | Frontend HMR | `cd frontend && npm run dev` → http://localhost:5173 (proxies `/api`) |

--- a/docs/reference/frontend.md
+++ b/docs/reference/frontend.md
@@ -95,6 +95,8 @@ The **Dashboard tab** is the entry view: public reciter browse/search/filter/pla
 
 Shared player rule: deliberate navigation resumes playback even when the audio was paused. This includes ayah/surah steps, surah or delivery changes, progress/filmstrip/line seeks, Timestamps keyboard navigation, validation jumps, and manual shuffle/random-reciter triggers. Passive inspection (popovers, hover previews, zoom/pan, speed/download/bookmark/display toggles) must stay paused.
 
+Recitation-animation (`lib/recitation-animation/`, mounted by `NowReciting` above the player in both Dashboard + Timestamps tabs): the `AyahFilmstrip` ayah scrubber and the `LineAnimation` teleprompter are **recitation-driven, not clock-driven**. Both map playback time → the recited word via the shared `findActiveAt` (`recitation-active.ts`): a flat per-occurrence interval timeline that returns `null` during silence gaps and travels backward on loopbacks (the raw, non-deduped occurrences the shard retains "for the filmstrip" — see [timestamps-job.md](timestamps-job.md) §1a). The filmstrip's per-verse cell bar fills to the recited word's **duration-weighted** position in the verse (`filmstrip-model.ts`), so a within-verse word loopback rewinds the bar and a cross-verse loopback scrolls the strip back (same glide in both `snap`/`hybrid` modes); during silence the active cell de-highlights, the cursor/needle hide, and the bar **freezes**. The bottom `PlayerProgress` scrubber stays time-linear — only the cell bar is recitation-adaptive.
+
 ### `lib/catalog/`, `lib/refs/`, `lib/icons/`
 
 | Path | Role |

--- a/inspector/frontend/src/lib/components/player/NowReciting.svelte
+++ b/inspector/frontend/src/lib/components/player/NowReciting.svelte
@@ -19,6 +19,7 @@
     import { exitLoop } from '../../playback/loop';
     import {
         AyahFilmstrip,
+        buildFilmstripModel,
         ControlIcon,
         RecitationSection,
         type AnimUnit,
@@ -71,6 +72,10 @@
     let colorInput = $state<HTMLInputElement | undefined>(undefined);
 
     const config = $derived($recitationConfigStore);
+    // Recitation-correct cell geometry + per-verse word fractions, rebuilt once
+    // per chapter. Duration-weighted: the cell bar fills to the recited word's
+    // share of the verse's spoken time.
+    const filmstripModel = $derived(buildFilmstripModel(units, 'duration'));
     const near = (a: number, b: number): boolean => Math.abs(a - b) < 0.001;
     const upcomingLabel = $derived(
         near(config.unreachedOpacity, 0.8) ? 'full'
@@ -282,7 +287,7 @@
             />
         {/if}
 
-        {#if config.filmstripShow && ayahs.length}
+        {#if config.filmstripShow && filmstripModel.cells.length}
             <div class="strip-wrap">
                 {#if isTimestamps}
                     <div class="strip-bm" role="group" aria-label="Bookmarks">
@@ -302,7 +307,8 @@
                 <div class="strip-flex">
                     <AyahFilmstrip
                         bind:this={filmstrip}
-                        {ayahs}
+                        {units}
+                        model={filmstripModel}
                         durationMs={$playerContext.durationMs}
                         {getTimeMs}
                         {playing}

--- a/inspector/frontend/src/lib/recitation-animation/AyahFilmstrip.svelte
+++ b/inspector/frontend/src/lib/recitation-animation/AyahFilmstrip.svelte
@@ -1,70 +1,96 @@
 <script lang="ts">
     /**
-     * Center-anchored ayah filmstrip — a non-linear, by-ayah scrubber that sits
-     * above the (linear) progress bar. Cells = ayahs, width
-     * proportional-with-normalization (min/max clamp). A fixed center needle
-     * marks "now"; the strip slides so the live playhead stays centered. Manual
-     * drag scrubs; click jumps. Three motion models (config.filmstripMotion):
+     * Center-anchored ayah filmstrip — a by-ayah scrubber that sits above the
+     * (linear) progress bar. Cells = ayahs, width proportional to each verse's
+     * canonical recited length (min/max clamp). A fixed center needle marks
+     * "now"; the strip slides so the live recited position stays centered.
+     *
+     * Recitation-driven, not clock-driven: the active cell + its progress fill
+     * follow which WORD is being recited (via the shared `findActiveAt`
+     * timeline), so silences freeze it and loopbacks travel it backward — the
+     * strip and the teleprompter line stay in lockstep. Three motion models
+     * (config.filmstripMotion):
      *   - tuner:  continuous center; drag scrubs exact time.
      *   - hybrid: continuous center; drag snaps to whole ayahs on release.
      *   - snap:   center the active cell only when the ayah changes; drag = snap.
      *
-     * Surface-agnostic: fed ayah boundaries + a time accessor + an onSeek cb.
+     * User scrub/drag/click stays TIME-based (seeking); playback is the only
+     * recitation-driven path. Surface-agnostic: fed `units` + a prebuilt
+     * `FilmstripModel` + a time accessor + an onSeek cb.
      */
     import { type RecitationAnimConfig } from './config';
-    import type { AyahBoundary } from './types';
+    import type { FilmstripModel } from './filmstrip-model';
+    import { buildSortedIntervals, findActiveAt } from './recitation-active';
+    import type { AnimUnit } from './types';
 
     interface Props {
-        ayahs: AyahBoundary[];
+        units: AnimUnit[];
+        model: FilmstripModel;
         durationMs: number;
         getTimeMs: () => number;
         playing: boolean;
         config: RecitationAnimConfig;
         onSeek: (_ms: number) => void;
-        /** Preview-highlight the ayah spanning this time (e.g. progress-bar
+        /** Preview-highlight the ayah recited at this time (e.g. progress-bar
          *  hover). null = no preview. */
         hoverMs?: number | null;
         /** Active progress-bar *drag* time — the strip scroll-follows it (both
          *  motion modes) while non-null, suspending the playback driver. null =
          *  not scrubbing. */
         scrubMs?: number | null;
-        /** Speculative-prewarm hook: fired with a cell's start (ms) when the
-         *  pointer enters it, so the surface can warm that position. Optional —
-         *  surfaces that don't prewarm omit it. */
+        /** Speculative-prewarm hook: fired with a cell's seek (ms) when the
+         *  pointer enters it, so the surface can warm that position. Optional. */
         onHoverPrewarm?: (_ms: number) => void;
     }
 
     let {
-        ayahs, getTimeMs, playing, config, onSeek,
+        units, model, getTimeMs, playing, config, onSeek,
         hoverMs = null, scrubMs = null, onHoverPrewarm,
     }: Props = $props();
 
     const clamp = (lo: number, hi: number, v: number): number => Math.min(hi, Math.max(lo, v));
     const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
 
+    /** A backward verse jump, or a forward verse skip larger than this many
+     *  cells, is a loopback/seek discontinuity → glide rather than teleport. */
+    const JUMP_CELL_GAP = 1;
+    /** Min backward cell-fill delta (fraction) that counts as a within-verse
+     *  word loopback worth gliding. */
+    const JUMP_FRAC_EPS = 0.01;
+    /** How long the loopback/seek glide eases before direct tracking resumes. */
+    const GLIDE_MS = 320;
+
     let containerEl = $state<HTMLDivElement | undefined>(undefined);
     let cw = $state(0); // container width
-    let nowMs = $state(0);
     let offset = $state(0); // px scrolled into the cells region (needle position)
-    let animate = $state(false); // CSS transition on the track (snap moves only)
+    let animate = $state(false); // CSS transition on the track (snap + glide moves)
     let dragging = $state(false);
+
+    // Recitation-driven playback state (written by the rAF driver / refresh).
+    let activeIdx = $state(-1); // cell of the recited word; holds during silence
+    let cellFrac = $state(0); // word-proportional fill of the active cell
+    let silent = $state(false); // in a silence gap → frozen, no highlight/cursor
+    let frozenIdx = $state(-1); // last active cell, held while silent
+    let jumping = $state(false); // mid-glide → cell-fill eases too
+    let lastActiveUnit = -1; // O(1) fast-path hint for findActiveAt
+    let glideTimer: ReturnType<typeof setTimeout> | null = null;
 
     interface Cell {
         ayah: number;
-        startMs: number;
-        endMs: number;
-        dur: number;
         w: number;
         cumBefore: number; // px before this cell's left (cells + gaps)
     }
 
+    // Cell widths from each verse's CANONICAL recited duration — never inflated
+    // by a loopback's later occurrence (unlike the old ayah max-end boundary).
     const cells = $derived.by((): Cell[] => {
-        if (!ayahs.length) return [];
-        const durs = ayahs.map((a) => Math.max(1, a.endMs - a.startMs));
+        const mc = model.cells;
+        if (!mc.length) return [];
+        const durs = mc.map((c) => Math.max(1, c.canonDurSec * 1000));
         const maxDur = Math.max(...durs);
         const out: Cell[] = [];
         let cum = 0;
-        for (let i = 0; i < ayahs.length; i++) {
+        for (let i = 0; i < mc.length; i++) {
             const propW = (durs[i]! / maxDur) * config.filmstripMaxCellPx;
             const w = Math.round(
                 clamp(
@@ -73,69 +99,43 @@
                     lerp(config.filmstripMinCellPx, propW, config.filmstripProportional),
                 ),
             );
-            out.push({
-                ayah: ayahs[i]!.ayah,
-                startMs: ayahs[i]!.startMs,
-                endMs: ayahs[i]!.endMs,
-                dur: durs[i]!,
-                w,
-                cumBefore: cum,
-            });
+            out.push({ ayah: mc[i]!.ayah, w, cumBefore: cum });
             cum += w + config.filmstripGapPx;
         }
         return out;
     });
 
+    const sorted = $derived(buildSortedIntervals(units));
     const lastRight = $derived(
         cells.length ? cells[cells.length - 1]!.cumBefore + cells[cells.length - 1]!.w : 0,
     );
     const pad = $derived(cw / 2); // leading/trailing spacer so edges can center
 
-    // Cells are produced in temporal order from `ayahs` (built by
-    // loadChapterRecitation), so startMs is ascending. Binary search the
-    // largest i where cells[i].startMs <= t — this collapses the original
-    // "inside [start,end)" and "last with start <= t" branches (both return
-    // the same idx for non-overlapping cells).
-    function indexForTime(t: number): number {
-        const n = cells.length;
-        if (n === 0 || t < cells[0]!.startMs) return -1;
-        let lo = 0;
-        let hi = n - 1;
-        while (lo < hi) {
-            const mid = (lo + hi + 1) >> 1;
-            if (cells[mid]!.startMs <= t) lo = mid;
-            else hi = mid - 1;
-        }
-        return lo;
+    interface Reci { unitIdx: number; idx: number; frac: number; }
+
+    /** Map a time (seconds) to the recited cell + its word-proportional fill,
+     *  or null during a silence gap. `hint` seeds the O(1) fast-path (-1 for
+     *  random-access lookups like hover/scrub). */
+    function recitationAt(tSec: number, hint: number): Reci | null {
+        const h = findActiveAt(units, sorted, tSec, hint);
+        if (!h) return null;
+        const idx = model.cellOfUnit[h.unitIdx] ?? -1;
+        if (idx < 0) return null;
+        const cell = model.cells[idx]!;
+        const wf = cell.words[h.unitIdx - cell.unitStart];
+        const span = h.ivEnd - h.ivStart;
+        const intra = span > 0 ? clamp(0, 1, (tSec - h.ivStart) / span) : 0;
+        const frac = wf ? wf.frac0 + intra * (wf.frac1 - wf.frac0) : 0;
+        return { unitIdx: h.unitIdx, idx, frac };
     }
-    const activeIdx = $derived(indexForTime(nowMs));
-    const hoverIdx = $derived(hoverMs == null ? -1 : indexForTime(hoverMs));
-    // Snap mode has no moving needle (the strip is always centered on the active
-    // cell), so instead we highlight the cell under where the invisible needle
-    // would sit — i.e. the nearest cell to the current scroll offset. While
-    // playing it equals the active cell; while dragging it follows the drag,
-    // showing which ayah a release will snap to. -1 (off) outside snap mode.
-    const cursorIdx = $derived(config.filmstripMotion === 'snap' ? nearestCell(offset) : -1);
 
     function offsetForCellCenter(i: number): number {
         const c = cells[i];
         return c ? c.cumBefore + c.w / 2 : 0;
     }
-    function continuousOffset(t: number): number {
-        const i = indexForTime(t);
-        if (i < 0) return 0;
-        const c = cells[i]!;
-        return c.cumBefore + clamp(0, 1, (t - c.startMs) / c.dur) * c.w;
-    }
-    function timeAtOffset(off: number): number {
-        for (let i = 0; i < cells.length; i++) {
-            const c = cells[i]!;
-            if (off <= c.cumBefore + c.w) {
-                const f = clamp(0, 1, (off - c.cumBefore) / c.w);
-                return c.startMs + f * c.dur;
-            }
-        }
-        return cells.length ? cells[cells.length - 1]!.endMs : 0;
+    function offsetForReci(r: Reci): number {
+        const c = cells[r.idx];
+        return c ? c.cumBefore + r.frac * c.w : offset;
     }
     function nearestCell(off: number): number {
         let best = -1;
@@ -149,59 +149,130 @@
         }
         return best;
     }
+    /** Map a strip offset back to a canonical seek time (ms) — tuner drag. */
+    function timeAtOffset(off: number): number {
+        for (let i = 0; i < cells.length; i++) {
+            const c = cells[i]!;
+            if (off <= c.cumBefore + c.w) {
+                const f = clamp(0, 1, (off - c.cumBefore) / c.w);
+                const mc = model.cells[i]!;
+                return (mc.canonStartSec + f * mc.canonDurSec) * 1000;
+            }
+        }
+        const last = model.cells[model.cells.length - 1];
+        return last ? (last.canonStartSec + last.canonDurSec) * 1000 : 0;
+    }
+    /** The seek target for picking a cell — the verse's canonical first start. */
+    function seekMsForCell(i: number): number {
+        const mc = model.cells[i];
+        return mc ? mc.canonStartSec * 1000 : 0;
+    }
+    /** Cell recited at a given time (random access) — hover/scrub preview. */
+    function cellViaTime(ms: number): number {
+        const h = findActiveAt(units, sorted, ms / 1000, -1);
+        return h ? (model.cellOfUnit[h.unitIdx] ?? -1) : -1;
+    }
 
-    // rAF while playing: track time, and (tuner/hybrid) keep the playhead centered.
+    const hoverIdx = $derived(hoverMs == null ? -1 : cellViaTime(hoverMs));
+    // Snap mode has no moving needle (the strip is always centered on the active
+    // cell), so instead we ring the cell under where the invisible needle would
+    // sit. Hidden during silence (no cursor while frozen). -1 outside snap mode.
+    const cursorIdx = $derived(
+        config.filmstripMotion === 'snap' && !silent ? nearestCell(offset) : -1,
+    );
+
+    function setFill(frac: number): void {
+        containerEl?.style.setProperty('--cell-active-fill', clamp(0, 1, frac) * 100 + '%');
+    }
+
+    /** A recitation discontinuity (loopback / seek) vs a smooth advance. */
+    function isJump(prevIdx: number, newIdx: number, prevFrac: number, newFrac: number): boolean {
+        if (prevIdx < 0) return false; // first activation — no glide
+        if (newIdx < prevIdx) return true; // back to an earlier verse
+        if (newIdx - prevIdx > JUMP_CELL_GAP) return true; // forward verse skip
+        if (newIdx === prevIdx && newFrac < prevFrac - JUMP_FRAC_EPS) return true; // word loopback
+        return false;
+    }
+    function triggerGlide(): void {
+        jumping = true;
+        animate = true;
+        if (glideTimer) clearTimeout(glideTimer);
+        glideTimer = setTimeout(() => {
+            jumping = false;
+            // Snap keeps its track transition on (it always glides ayah hops);
+            // hybrid/tuner return to direct per-frame writes.
+            if (config.filmstripMotion !== 'snap') animate = false;
+        }, GLIDE_MS);
+    }
+
+    /** One rAF step of recitation-driven playback. */
+    function drivePlayback(): void {
+        const tSec = (getTimeMs() + config.leadMs) / 1000;
+        const r = recitationAt(tSec, lastActiveUnit);
+        if (!r) {
+            // Silence: freeze — hold offset + fill, drop highlight/cursor. The
+            // last active cell (frozenIdx) stays as a de-accented, held bar.
+            silent = true;
+            return;
+        }
+        lastActiveUnit = r.unitIdx;
+        const jumped = isJump(activeIdx, r.idx, cellFrac, r.frac);
+        silent = false;
+        activeIdx = r.idx;
+        cellFrac = r.frac;
+        frozenIdx = r.idx;
+        setFill(r.frac);
+        if (jumped) triggerGlide();
+        if (config.filmstripMotion === 'snap') return; // centering effect owns offset
+        if (!jumping) animate = false;
+        offset = offsetForReci(r);
+    }
+
+    // rAF while playing: drive the recitation mapping (all modes).
     $effect(() => {
         if (!playing) return;
         let raf = 0;
         const loop = (): void => {
-            nowMs = getTimeMs();
-            if (!dragging && scrubMs == null && config.filmstripMotion !== 'snap') {
-                animate = false;
-                offset = continuousOffset(nowMs);
-            }
+            if (!dragging && scrubMs == null) drivePlayback();
             raf = requestAnimationFrame(loop);
         };
         raf = requestAnimationFrame(loop);
         return () => cancelAnimationFrame(raf);
     });
 
-    // Per-frame fill is driven by ONE CSS variable on the container instead of
-    // a `style:width` write on every cell (which previously rebuilt N inline
-    // styles per frame — 286 for Baqarah). The active cell reads the var via
-    // `.cell.active .cell-fill { width: var(--cell-active-fill, 0%) }`;
-    // reached cells are pinned to 100% and future cells to 0% in plain CSS.
-    $effect(() => {
-        if (!containerEl) return;
-        const i = activeIdx;
-        if (i < 0) {
-            containerEl.style.removeProperty('--cell-active-fill');
-            return;
-        }
-        const c = cells[i];
-        if (!c) return;
-        const f = clamp(0, 1, (nowMs - c.startMs) / c.dur);
-        containerEl.style.setProperty('--cell-active-fill', f * 100 + '%');
-    });
-
-    // Snap mode: glide the active cell to center when the ayah changes. Yields
-    // to a progress-bar scrub (the scroll-follow effect owns offset then).
+    // Snap mode: glide the active cell to center when the ayah changes (now
+    // recitation-driven, so a cross-verse loopback scrolls back here). Yields to
+    // a progress-bar scrub (the scroll-follow effect owns offset then).
     $effect(() => {
         void activeIdx;
         if (config.filmstripMotion !== 'snap' || dragging || scrubMs != null
-            || activeIdx < 0 || cw === 0) return;
+            || silent || activeIdx < 0 || cw === 0) return;
         animate = true;
         offset = offsetForCellCenter(activeIdx);
     });
 
     // Progress-bar drag → scroll-follow the dragged time (both motion modes).
-    // Direct offset write (no CSS transition) mirrors the strip's own drag, so
-    // it tracks the pointer smoothly; the playback driver above is suspended
-    // while scrubMs is non-null. On release the parent seeks + the strip settles.
+    // Maps the time through the recitation timeline so it tracks the recited
+    // position (correct under overlap/repeats). The playback driver is suspended
+    // while scrubMs is non-null. Silence in the scrub → hold (no move).
     $effect(() => {
         if (scrubMs == null || cw === 0) return;
         animate = false;
-        offset = clamp(0, lastRight, continuousOffset(scrubMs));
+        const r = recitationAt(scrubMs / 1000, -1);
+        if (r) offset = clamp(0, lastRight, offsetForReci(r));
+    });
+
+    // Reset recitation state when the chapter (units identity) changes.
+    $effect(() => {
+        void units; // track
+        activeIdx = -1;
+        cellFrac = 0;
+        silent = false;
+        frozenIdx = -1;
+        lastActiveUnit = -1;
+        if (glideTimer) clearTimeout(glideTimer);
+        jumping = false;
+        containerEl?.style.removeProperty('--cell-active-fill');
     });
 
     // Drag — pan the strip; release scrubs (tuner) or snaps to an ayah.
@@ -240,7 +311,7 @@
             if (i >= 0) {
                 animate = true;
                 offset = offsetForCellCenter(i);
-                onSeek(cells[i]!.startMs);
+                onSeek(seekMsForCell(i));
             }
         }
     }
@@ -250,7 +321,7 @@
         if (i < 0) return;
         animate = true;
         offset = offsetForCellCenter(i);
-        onSeek(cells[i]!.startMs);
+        onSeek(seekMsForCell(i));
     }
 
     /** Map a viewport x to the cell index under it (needle at cw/2; track
@@ -262,30 +333,44 @@
         return nearestCell(clamp(0, lastRight, off));
     }
 
-    /** Speculative-prewarm hook on pointer hover (no button): warm the position
-     *  of the cell under the pointer. Suppressed while dragging (the strip owns
-     *  the pointer then). */
+    /** Speculative-prewarm hook on pointer hover (no button): warm the seek
+     *  position of the cell under the pointer. Suppressed while dragging. */
     function onHoverMove(e: PointerEvent): void {
         if (!onHoverPrewarm || dragging) return;
         const i = cellAtClientX(e.clientX);
-        if (i >= 0) onHoverPrewarm(cells[i]!.startMs);
+        if (i >= 0) onHoverPrewarm(seekMsForCell(i));
     }
 
     /** Re-sync after a seek while paused (parent calls this). */
     export function refresh(): void {
-        nowMs = getTimeMs();
         if (cw === 0) return;
+        const r = recitationAt((getTimeMs() + config.leadMs) / 1000, -1);
+        if (!r) {
+            // Landed in a gap → hold the frozen state (or nothing, pre-first).
+            silent = true;
+            return;
+        }
+        silent = false;
+        activeIdx = r.idx;
+        cellFrac = r.frac;
+        frozenIdx = r.idx;
+        lastActiveUnit = r.unitIdx;
+        setFill(r.frac);
         animate = true;
-        offset = config.filmstripMotion === 'tuner'
-            ? continuousOffset(nowMs)
-            : (activeIdx >= 0 ? offsetForCellCenter(activeIdx) : offset);
+        offset = config.filmstripMotion === 'snap'
+            ? offsetForCellCenter(r.idx)
+            : offsetForReci(r);
     }
 
     /** Force the new chapter's first ayah into view before audio canplay. */
     export function showFirstAyah(): void {
-        const first = cells[0];
-        if (!first) return;
-        nowMs = first.startMs;
+        if (!cells.length) return;
+        activeIdx = -1;
+        cellFrac = 0;
+        silent = false;
+        frozenIdx = -1;
+        lastActiveUnit = -1;
+        containerEl?.style.removeProperty('--cell-active-fill');
         animate = true;
         offset = offsetForCellCenter(0);
     }
@@ -312,7 +397,7 @@
                 const i = clamp(0, cells.length - 1, (activeIdx < 0 ? 0 : activeIdx) + d);
                 animate = true;
                 offset = offsetForCellCenter(i);
-                onSeek(cells[i]!.startMs);
+                onSeek(seekMsForCell(i));
             }
         }}
     >
@@ -326,20 +411,21 @@
             {#each cells as c, i (c.ayah)}
                 <div
                     class="cell"
-                    class:active={i === activeIdx}
-                    class:reached={i < activeIdx}
+                    class:active={!silent && i === activeIdx}
+                    class:reached={i < (silent ? frozenIdx : activeIdx)}
+                    class:frozen={silent && i === frozenIdx}
                     class:preview={i === hoverIdx && i !== activeIdx}
                     class:cursor={i === cursorIdx}
                     style:width="{c.w}px"
                     style:margin-right="{config.filmstripGapPx}px"
                 >
-                    <div class="cell-fill"></div>
+                    <div class="cell-fill" class:glide={jumping && i === activeIdx}></div>
                     <span class="cell-num">{c.ayah}</span>
                 </div>
             {/each}
             <div class="pad" style:width="{pad}px"></div>
         </div>
-        {#if config.filmstripMotion !== 'snap'}
+        {#if config.filmstripMotion !== 'snap' && !silent}
             <div class="needle" aria-hidden="true"></div>
         {/if}
         <div class="fade fade-l" aria-hidden="true"></div>
@@ -409,6 +495,12 @@
         border-color: var(--accent);
         background: var(--accent-tint-soft);
     }
+    /* Frozen cell — the verse held under a silence pause. De-accented (the
+     *  highlight drops) but keeps its partial fill so the bar reads "held, not
+     *  finished" until recitation regenerates. */
+    .cell.frozen {
+        border-color: var(--border-default);
+    }
     /* Snap-mode cursor cell — the ayah under the invisible needle (active cell
      *  while playing, drag target while scrubbing). An inset accent ring keeps it
      *  distinct from `.active`'s tinted fill so both can show at once mid-drag. */
@@ -416,7 +508,7 @@
         border-color: var(--accent);
         box-shadow: inset 0 0 0 1px var(--accent);
     }
-    /* Progress-bar hover preview — the verse spanned by the hovered time. */
+    /* Progress-bar hover preview — the verse recited at the hovered time. */
     .cell.preview {
         border-color: var(--accent-strong);
         border-style: dashed;
@@ -432,14 +524,20 @@
         background: var(--accent-tint);
         pointer-events: none;
     }
-    /* Active cell width is driven by `--cell-active-fill` on the .filmstrip
-       container, written once per rAF tick by the imperative effect. */
-    .cell.active .cell-fill {
+    /* Active + frozen cells read the per-frame fill var (written by the driver);
+       the frozen one simply holds the last value. */
+    .cell.active .cell-fill,
+    .cell.frozen .cell-fill {
         width: var(--cell-active-fill, 0%);
     }
     .cell.reached .cell-fill {
         width: 100%;
         background: var(--accent-tint-soft);
+    }
+    /* Eased fill ONLY during a loopback/seek glide — never a permanent
+       transition (that would lag every forward-play frame). */
+    .cell.active .cell-fill.glide {
+        transition: width var(--t-base, 200ms) var(--ease-out-quart, ease);
     }
     .cell-num {
         position: relative;
@@ -483,7 +581,8 @@
     }
     @media (prefers-reduced-motion: reduce) {
         .track.animate,
-        .track.snap-glide.animate {
+        .track.snap-glide.animate,
+        .cell.active .cell-fill.glide {
             transition: none;
         }
     }

--- a/inspector/frontend/src/lib/recitation-animation/AyahFilmstrip.svelte
+++ b/inspector/frontend/src/lib/recitation-animation/AyahFilmstrip.svelte
@@ -15,8 +15,12 @@
      *   - snap:   center the active cell only when the ayah changes; drag = snap.
      *
      * User scrub/drag/click stays TIME-based (seeking); playback is the only
-     * recitation-driven path. Surface-agnostic: fed `units` + a prebuilt
-     * `FilmstripModel` + a time accessor + an onSeek cb.
+     * recitation-driven path. Every deliberate scroll (click, key, snap-center,
+     * loopback, linear-bar seek) runs through ONE JS tween (`glideTo`) with
+     * distance-proportional duration + ease-in-out, so a one-cell hop and a
+     * scroll to the far end of the strip feel like the same motion. Live drag
+     * and hybrid playback tracking write `offset` directly. Surface-agnostic:
+     * fed `units` + a prebuilt `FilmstripModel` + a time accessor + an onSeek cb.
      */
     import { type RecitationAnimConfig } from './config';
     import type { FilmstripModel } from './filmstrip-model';
@@ -57,13 +61,21 @@
     /** Min backward cell-fill delta (fraction) that counts as a within-verse
      *  word loopback worth gliding. */
     const JUMP_FRAC_EPS = 0.01;
-    /** How long the loopback/seek glide eases before direct tracking resumes. */
-    const GLIDE_MS = 320;
+
+    // ---- scroll-glide tuning (distance-proportional, single feel everywhere) ----
+    /** ms per px of scroll distance — the glide's velocity (↑ = slower). */
+    const GLIDE_MS_PER_PX = 0.9;
+    /** Floor so a tiny hop is still a visible glide, not a snap. */
+    const GLIDE_MIN_MS = 300;
+    /** Cap so a full-film seek stays a smooth scroll-through, not endless. */
+    const GLIDE_MAX_MS = 1500;
+    /** An audio-time jump beyond this in one frame ⇒ a seek (glide), not the
+     *  normal forward creep of playback. */
+    const SEEK_JUMP_MS = 400;
 
     let containerEl = $state<HTMLDivElement | undefined>(undefined);
     let cw = $state(0); // container width
     let offset = $state(0); // px scrolled into the cells region (needle position)
-    let animate = $state(false); // CSS transition on the track (snap + glide moves)
     let dragging = $state(false);
 
     // Recitation-driven playback state (written by the rAF driver / refresh).
@@ -73,7 +85,19 @@
     let frozenIdx = $state(-1); // last active cell, held while silent
     let jumping = $state(false); // mid-glide → cell-fill eases too
     let lastActiveUnit = -1; // O(1) fast-path hint for findActiveAt
-    let glideTimer: ReturnType<typeof setTimeout> | null = null;
+    let lastTimeMs = -1; // previous frame's audio time, for seek detection
+    let fillGlideTimer: ReturnType<typeof setTimeout> | null = null;
+
+    // JS scroll tween — the single source of animated `offset` moves. Distance-
+    // proportional duration + soft ease, so a one-cell hop and a scroll to the
+    // far end of the strip feel like the same motion, just longer.
+    interface Tween { from: number; to: number; startT: number; dur: number; }
+    let tween: Tween | null = null;
+    let tweenRaf = 0;
+    const reducedMotion = typeof matchMedia === 'function'
+        && matchMedia('(prefers-reduced-motion: reduce)').matches;
+    // ease-in-out sine — soft start AND stop (the old ease-out started abruptly).
+    const easeInOut = (p: number): number => 0.5 - Math.cos(Math.PI * p) / 2;
 
     interface Cell {
         ayah: number;
@@ -185,6 +209,54 @@
         containerEl?.style.setProperty('--cell-active-fill', clamp(0, 1, frac) * 100 + '%');
     }
 
+    // ---- scroll tween: the one animated path that moves `offset` ----
+    function stepTween(now: number): void {
+        const t = tween;
+        if (!t) { tweenRaf = 0; return; }
+        const p = clamp(0, 1, (now - t.startT) / t.dur);
+        offset = t.from + (t.to - t.from) * easeInOut(p);
+        if (p >= 1) { tween = null; tweenRaf = 0; return; }
+        tweenRaf = requestAnimationFrame(stepTween);
+    }
+    /** Distance-proportional glide duration (clamped). The shared "feel". */
+    function glideDur(dist: number): number {
+        return clamp(GLIDE_MIN_MS, dist * GLIDE_MS_PER_PX, GLIDE_MAX_MS);
+    }
+    /** Animate `offset` to a target — the one animated path for every deliberate
+     *  strip scroll (click, key, snap-center, loopback, seek). Strip only. */
+    function glideTo(target: number): void {
+        target = clamp(0, lastRight, target);
+        const dist = Math.abs(target - offset);
+        if (reducedMotion || dist < 1) {
+            tween = null;
+            offset = target;
+            return;
+        }
+        tween = { from: offset, to: target, startT: performance.now(), dur: glideDur(dist) };
+        if (!tweenRaf) tweenRaf = requestAnimationFrame(stepTween);
+    }
+    function cancelTween(): void {
+        tween = null;
+        if (tweenRaf) cancelAnimationFrame(tweenRaf);
+        tweenRaf = 0;
+    }
+    /** Ease the active cell's fill bar over `dur` (a loopback rewind or a seek),
+     *  matched to the strip glide. Off for normal forward play (the bar tracks
+     *  per-frame with no transition, so it can't lag). */
+    function armFillGlide(dur: number): void {
+        if (reducedMotion) return;
+        containerEl?.style.setProperty('--cell-glide-dur', dur + 'ms');
+        jumping = true;
+        if (fillGlideTimer) clearTimeout(fillGlideTimer);
+        fillGlideTimer = setTimeout(() => { jumping = false; }, dur);
+    }
+    /** A discrete strip move (loopback / seek / user nav): glide the strip AND
+     *  ease the fill over the same distance-proportional time. */
+    function jumpTo(target: number): void {
+        armFillGlide(glideDur(Math.abs(clamp(0, lastRight, target) - offset)));
+        glideTo(target);
+    }
+
     /** A recitation discontinuity (loopback / seek) vs a smooth advance. */
     function isJump(prevIdx: number, newIdx: number, prevFrac: number, newFrac: number): boolean {
         if (prevIdx < 0) return false; // first activation — no glide
@@ -193,44 +265,51 @@
         if (newIdx === prevIdx && newFrac < prevFrac - JUMP_FRAC_EPS) return true; // word loopback
         return false;
     }
-    function triggerGlide(): void {
-        jumping = true;
-        animate = true;
-        if (glideTimer) clearTimeout(glideTimer);
-        glideTimer = setTimeout(() => {
-            jumping = false;
-            // Snap keeps its track transition on (it always glides ayah hops);
-            // hybrid/tuner return to direct per-frame writes.
-            if (config.filmstripMotion !== 'snap') animate = false;
-        }, GLIDE_MS);
-    }
 
     /** One rAF step of recitation-driven playback. */
     function drivePlayback(): void {
-        const tSec = (getTimeMs() + config.leadMs) / 1000;
+        const nowMs = getTimeMs();
+        const tSec = (nowMs + config.leadMs) / 1000;
         const r = recitationAt(tSec, lastActiveUnit);
+        // A large audio-time jump in one frame is a seek (e.g. a linear-bar
+        // click), not the normal forward creep — glide to it like any other.
+        const seeked = lastTimeMs >= 0 && Math.abs(nowMs - lastTimeMs) > SEEK_JUMP_MS;
+        lastTimeMs = nowMs;
         if (!r) {
             // Silence: freeze — hold offset + fill, drop highlight/cursor. The
             // last active cell (frozenIdx) stays as a de-accented, held bar.
             silent = true;
             return;
         }
+        const prevIdx = activeIdx;
+        const prevFrac = cellFrac;
         lastActiveUnit = r.unitIdx;
-        const jumped = isJump(activeIdx, r.idx, cellFrac, r.frac);
+        const discont = seeked || isJump(prevIdx, r.idx, prevFrac, r.frac);
         silent = false;
         activeIdx = r.idx;
         cellFrac = r.frac;
         frozenIdx = r.idx;
         setFill(r.frac);
-        if (jumped) triggerGlide();
-        if (config.filmstripMotion === 'snap') return; // centering effect owns offset
-        if (!jumping) animate = false;
-        offset = offsetForReci(r);
+
+        const snap = config.filmstripMotion === 'snap';
+        const target = snap ? offsetForCellCenter(r.idx) : offsetForReci(r);
+        if (discont) {
+            jumpTo(target); // loopback / seek → glide strip + ease bar
+            return;
+        }
+        if (snap) {
+            // Smooth forward play: center the new verse on each ayah change.
+            if (r.idx !== prevIdx) glideTo(target);
+            return;
+        }
+        if (tween) return; // a glide is still settling — let it own offset
+        offset = target; // hybrid/tuner continuous tracking
     }
 
     // rAF while playing: drive the recitation mapping (all modes).
     $effect(() => {
         if (!playing) return;
+        lastTimeMs = -1; // don't read the first frame as a seek
         let raf = 0;
         const loop = (): void => {
             if (!dragging && scrubMs == null) drivePlayback();
@@ -240,24 +319,13 @@
         return () => cancelAnimationFrame(raf);
     });
 
-    // Snap mode: glide the active cell to center when the ayah changes (now
-    // recitation-driven, so a cross-verse loopback scrolls back here). Yields to
-    // a progress-bar scrub (the scroll-follow effect owns offset then).
-    $effect(() => {
-        void activeIdx;
-        if (config.filmstripMotion !== 'snap' || dragging || scrubMs != null
-            || silent || activeIdx < 0 || cw === 0) return;
-        animate = true;
-        offset = offsetForCellCenter(activeIdx);
-    });
-
     // Progress-bar drag → scroll-follow the dragged time (both motion modes).
     // Maps the time through the recitation timeline so it tracks the recited
-    // position (correct under overlap/repeats). The playback driver is suspended
-    // while scrubMs is non-null. Silence in the scrub → hold (no move).
+    // position (correct under overlap/repeats). Direct follow (no glide) — you're
+    // scrubbing live. Silence in the scrub → hold (no move).
     $effect(() => {
         if (scrubMs == null || cw === 0) return;
-        animate = false;
+        cancelTween();
         const r = recitationAt(scrubMs / 1000, -1);
         if (r) offset = clamp(0, lastRight, offsetForReci(r));
     });
@@ -270,7 +338,9 @@
         silent = false;
         frozenIdx = -1;
         lastActiveUnit = -1;
-        if (glideTimer) clearTimeout(glideTimer);
+        lastTimeMs = -1;
+        cancelTween();
+        if (fillGlideTimer) clearTimeout(fillGlideTimer);
         jumping = false;
         containerEl?.style.removeProperty('--cell-active-fill');
     });
@@ -285,7 +355,7 @@
         moved = false;
         dragStartX = e.clientX;
         dragStartOffset = offset;
-        animate = false;
+        cancelTween(); // the drag owns offset now
         containerEl?.setPointerCapture(e.pointerId);
         window.addEventListener('pointermove', onPointerMove);
         window.addEventListener('pointerup', onPointerUp, { once: true });
@@ -309,8 +379,7 @@
         } else {
             const i = nearestCell(offset);
             if (i >= 0) {
-                animate = true;
-                offset = offsetForCellCenter(i);
+                glideTo(offsetForCellCenter(i));
                 onSeek(seekMsForCell(i));
             }
         }
@@ -319,8 +388,7 @@
         if (!containerEl) return;
         const i = cellAtClientX(clientX);
         if (i < 0) return;
-        animate = true;
-        offset = offsetForCellCenter(i);
+        glideTo(offsetForCellCenter(i));
         onSeek(seekMsForCell(i));
     }
 
@@ -355,11 +423,11 @@
         cellFrac = r.frac;
         frozenIdx = r.idx;
         lastActiveUnit = r.unitIdx;
+        lastTimeMs = -1; // resync; the next playing frame isn't a seek
         setFill(r.frac);
-        animate = true;
-        offset = config.filmstripMotion === 'snap'
+        jumpTo(config.filmstripMotion === 'snap'
             ? offsetForCellCenter(r.idx)
-            : offsetForReci(r);
+            : offsetForReci(r));
     }
 
     /** Force the new chapter's first ayah into view before audio canplay. */
@@ -370,8 +438,9 @@
         silent = false;
         frozenIdx = -1;
         lastActiveUnit = -1;
+        lastTimeMs = -1;
+        cancelTween();
         containerEl?.style.removeProperty('--cell-active-fill');
-        animate = true;
         offset = offsetForCellCenter(0);
     }
 </script>
@@ -395,16 +464,13 @@
                 e.preventDefault();
                 const d = e.key === 'ArrowRight' ? 1 : -1;
                 const i = clamp(0, cells.length - 1, (activeIdx < 0 ? 0 : activeIdx) + d);
-                animate = true;
-                offset = offsetForCellCenter(i);
+                glideTo(offsetForCellCenter(i));
                 onSeek(seekMsForCell(i));
             }
         }}
     >
         <div
             class="track"
-            class:animate
-            class:snap-glide={config.filmstripMotion === 'snap'}
             style:transform="translateX({-offset}px)"
         >
             <div class="pad" style:width="{pad}px"></div>
@@ -452,6 +518,9 @@
     .filmstrip:focus-visible {
         outline: none;
     }
+    /* The transform is driven imperatively by the JS scroll tween (`glideTo`),
+       so the track carries NO CSS transition — every scroll, near or far, runs
+       through one distance-proportional, ease-in-out animation. */
     .track {
         position: absolute;
         top: 50%;
@@ -461,14 +530,6 @@
         transform: translateX(0);
         will-change: transform;
         translate: 0 -50%;
-    }
-    .track.animate {
-        transition: transform var(--t-base, 200ms) var(--ease-out-quart, ease);
-    }
-    /* Snap mode glides whole-ayah hops, so it gets a longer, more dramatic
-       slide-and-settle (ease-out-expo) than hybrid's quick release snap. */
-    .track.snap-glide.animate {
-        transition: transform 560ms cubic-bezier(0.16, 1, 0.3, 1);
     }
     .pad {
         flex: 0 0 auto;
@@ -535,9 +596,10 @@
         background: var(--accent-tint-soft);
     }
     /* Eased fill ONLY during a loopback/seek glide — never a permanent
-       transition (that would lag every forward-play frame). */
+       transition (that would lag every forward-play frame). Duration is shared
+       with the strip scroll (`--cell-glide-dur`) so bar + scroll move as one. */
     .cell.active .cell-fill.glide {
-        transition: width var(--t-base, 200ms) var(--ease-out-quart, ease);
+        transition: width var(--cell-glide-dur, 320ms) ease-in-out;
     }
     .cell-num {
         position: relative;
@@ -579,9 +641,9 @@
         right: 0;
         background: linear-gradient(to left, var(--panel), transparent);
     }
+    /* The strip scroll is JS-driven and already skips the tween under reduced
+       motion (`reducedMotion` in glideTo); kill the fill-glide transition too. */
     @media (prefers-reduced-motion: reduce) {
-        .track.animate,
-        .track.snap-glide.animate,
         .cell.active .cell-fill.glide {
             transition: none;
         }

--- a/inspector/frontend/src/lib/recitation-animation/LineAnimation.svelte
+++ b/inspector/frontend/src/lib/recitation-animation/LineAnimation.svelte
@@ -23,6 +23,7 @@
         type HighlightCache,
     } from './engine/index-cache';
     import { fittedPrefixLength } from './line-window';
+    import { type ActiveHit, buildSortedIntervals, findActiveAt } from './recitation-active';
     import type { AnimUnit } from './types';
 
     /** U+06DD ARABIC END OF AYAH — the same glyph segment cards use. */
@@ -65,23 +66,8 @@
     const ayahRanges = $derived(ayahUnitRanges(units));
 
     // Flat sorted-by-start list of every occurrence interval across all units,
-    // for binary-search active lookup on fast-path miss. Each `units[i]` has
-    // ≥1 ascending intervals (`types.ts::AnimUnit`); reading-order is normally
-    // also temporal order so this is usually `units.map(u => u.intervals[0])`,
-    // but repeats can interleave — sort defensively. Built once per chapter
-    // (≈6.2k entries for Baqarah ≈ 150 KB, ~negligible).
-    interface SortedInterval { start: number; end: number; unitIdx: number; }
-    const sortedIntervals = $derived.by((): SortedInterval[] => {
-        const out: SortedInterval[] = [];
-        for (let i = 0; i < units.length; i++) {
-            const u = units[i]!;
-            for (const iv of u.intervals) {
-                out.push({ start: iv.start, end: iv.end, unitIdx: i });
-            }
-        }
-        out.sort((a, b) => a.start - b.start);
-        return out;
-    });
+    // for binary-search active lookup on fast-path miss. Built once per chapter.
+    const sortedIntervals = $derived(buildSortedIntervals(units));
     const ayahEndIdx = $derived(
         config.clearOnAyahEnd
             ? (ayahRanges.get(pageAyahKey)?.[1] ?? units.length)
@@ -204,47 +190,11 @@
         return fittedPrefixLength(fits);
     }
 
-    /** Active-unit lookup with O(1) fast-path and O(log N) bsearch fallback.
-     *  Returns the unit's GLOBAL index plus the occurrence interval containing
-     *  `t` (sweepChar needs the interval bounds to remap the canonical letter
-     *  timeline on repeats). null = silence gap. */
-    interface ActiveHit { unitIdx: number; ivStart: number; ivEnd: number; }
-    function findActive(t: number): ActiveHit | null {
-        const n = units.length;
-        if (n === 0) return null;
-        // Fast path: same unit as last frame, or the next unit. Covers the
-        // common forward-playback case in O(1) — no allocation, no bsearch.
-        for (const cand of [globalActive, globalActive + 1]) {
-            if (cand < 0 || cand >= n) continue;
-            const u = units[cand]!;
-            for (const iv of u.intervals) {
-                if (t >= iv.start && t < iv.end) {
-                    return { unitIdx: cand, ivStart: iv.start, ivEnd: iv.end };
-                }
-            }
-        }
-        // Fallback: bsearch the flat sorted interval list. Handles seek-back,
-        // silence gaps, and repeats where a later reading-order unit's first
-        // occurrence has not yet started but an earlier unit's repeat has.
-        const arr = sortedIntervals;
-        if (arr.length === 0 || t < arr[0]!.start) return null;
-        let lo = 0;
-        let hi = arr.length - 1;
-        while (lo < hi) {
-            const mid = (lo + hi + 1) >> 1;
-            if (arr[mid]!.start <= t) lo = mid;
-            else hi = mid - 1;
-        }
-        const iv = arr[lo]!;
-        if (t < iv.end) return { unitIdx: iv.unitIdx, ivStart: iv.start, ivEnd: iv.end };
-        return null;
-    }
-
     function doSweep(t?: number, hit?: ActiveHit | null): void {
         const tt = t ?? (getTimeMs() + config.leadMs) / 1000;
-        // `tick()` already computed `findActive` to drive paging; reuse its
+        // `tick()` already computed the active hit to drive paging; reuse its
         // result rather than re-bsearching. Structure-effect callers omit it.
-        const h = hit !== undefined ? hit : findActive(tt);
+        const h = hit !== undefined ? hit : findActiveAt(units, sortedIntervals, tt, globalActive);
         if (config.granularity === 'char') {
             sweepChar(tt, h);
             return;
@@ -376,7 +326,7 @@
     function tick(): void {
         if (!units.length) return;
         const t = (getTimeMs() + config.leadMs) / 1000;
-        const hit = findActive(t);
+        const hit = findActiveAt(units, sortedIntervals, t, globalActive);
         const ga = hit?.unitIdx ?? -1;
         if (ga >= 0) {
             const activeAyah = units[ga]!.ayahKey;

--- a/inspector/frontend/src/lib/recitation-animation/__tests__/filmstrip-model.test.ts
+++ b/inspector/frontend/src/lib/recitation-animation/__tests__/filmstrip-model.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildFilmstripModel } from '../filmstrip-model';
+import type { AnimUnit, TimeSpan } from '../types';
+
+function unit(location: string, intervals: Array<[number, number]>): AnimUnit {
+    const [surahRaw, ayahRaw, wordRaw] = location.split(':');
+    const surah = Number(surahRaw);
+    const ayah = Number(ayahRaw);
+    const spans: TimeSpan[] = intervals.map(([start, end]) => ({ start, end }));
+    return {
+        location,
+        ayahKey: `${surah}:${ayah}`,
+        surah,
+        ayah,
+        word: Number(wordRaw),
+        text: location,
+        start: spans[0]!.start,
+        end: spans[spans.length - 1]!.end,
+        intervals: spans,
+        letters: [],
+    };
+}
+
+// One verse, 3 words of canonical duration 1s / 2s / 1s. Word 2 is ALSO recited
+// again much later (a loopback) — its second occurrence must not inflate widths.
+const verse = [
+    unit('1:1:1', [[0, 1]]),
+    unit('1:1:2', [[1, 3], [10, 12]]),
+    unit('1:1:3', [[3, 4]]),
+];
+
+describe('buildFilmstripModel canonDurSec', () => {
+    it('sizes the cell by canonical first-occurrence durations, not the loopback', () => {
+        const model = buildFilmstripModel(verse, 'duration');
+        // 1 + 2 + 1 = 4s; a naive max(end)-min(start) would read 12s.
+        expect(model.cells[0]!.canonDurSec).toBeCloseTo(4, 6);
+    });
+
+    it('exposes the verse canonical start as the seek target', () => {
+        const model = buildFilmstripModel(verse, 'duration');
+        expect(model.cells[0]!.canonStartSec).toBeCloseTo(0, 6);
+    });
+});
+
+describe('buildFilmstripModel word fractions', () => {
+    it('weights word bands by duration (1/2/1 → quarters)', () => {
+        const words = buildFilmstripModel(verse, 'duration').cells[0]!.words;
+        expect(words.map((w) => w.frac0)).toEqual([0, 0.25, 0.75]);
+        expect(words.map((w) => w.frac1)).toEqual([0.25, 0.75, 1]);
+    });
+
+    it('weights word bands equally when asked (1/3 each)', () => {
+        const words = buildFilmstripModel(verse, 'equal').cells[0]!.words;
+        expect(words[0]!.frac1).toBeCloseTo(1 / 3, 6);
+        expect(words[1]!.frac1).toBeCloseTo(2 / 3, 6);
+        expect(words[2]!.frac1).toBeCloseTo(1, 6);
+    });
+});
+
+describe('buildFilmstripModel lookups', () => {
+    it('maps every unit to its verse cell across two verses', () => {
+        const units = [
+            unit('1:1:1', [[0, 1]]),
+            unit('1:1:2', [[1, 2]]),
+            unit('1:2:1', [[2, 3]]),
+        ];
+        const model = buildFilmstripModel(units, 'duration');
+        expect(Array.from(model.cellOfUnit)).toEqual([0, 0, 1]);
+        expect(model.indexByAyahKey.get('1:1')).toBe(0);
+        expect(model.indexByAyahKey.get('1:2')).toBe(1);
+    });
+
+    it('returns an empty model for no units', () => {
+        const model = buildFilmstripModel([], 'duration');
+        expect(model.cells).toEqual([]);
+        expect(model.cellOfUnit.length).toBe(0);
+    });
+});

--- a/inspector/frontend/src/lib/recitation-animation/__tests__/recitation-active.test.ts
+++ b/inspector/frontend/src/lib/recitation-animation/__tests__/recitation-active.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildSortedIntervals, findActiveAt } from '../recitation-active';
+import type { AnimUnit, TimeSpan } from '../types';
+
+/** Build a unit with explicit occurrence intervals (ascending). */
+function unit(location: string, intervals: Array<[number, number]>): AnimUnit {
+    const [surahRaw, ayahRaw, wordRaw] = location.split(':');
+    const surah = Number(surahRaw);
+    const ayah = Number(ayahRaw);
+    const spans: TimeSpan[] = intervals.map(([start, end]) => ({ start, end }));
+    return {
+        location,
+        ayahKey: `${surah}:${ayah}`,
+        surah,
+        ayah,
+        word: Number(wordRaw),
+        text: location,
+        start: spans[0]!.start,
+        end: spans[spans.length - 1]!.end,
+        intervals: spans,
+        letters: [],
+    };
+}
+
+describe('buildSortedIntervals', () => {
+    it('flattens every occurrence and sorts ascending by start', () => {
+        const units = [
+            unit('1:1:1', [[0, 1], [4, 5]]),
+            unit('1:1:2', [[1, 2]]),
+        ];
+        const sorted = buildSortedIntervals(units);
+        expect(sorted.map((s) => s.start)).toEqual([0, 1, 4]);
+        expect(sorted.map((s) => s.unitIdx)).toEqual([0, 1, 0]);
+    });
+
+    it('returns an empty list for no units', () => {
+        expect(buildSortedIntervals([])).toEqual([]);
+    });
+});
+
+describe('findActiveAt', () => {
+    const units = [
+        unit('1:1:1', [[0, 1]]),
+        unit('1:1:2', [[1, 2]]),
+        unit('1:1:3', [[3, 4]]),
+    ];
+    const sorted = buildSortedIntervals(units);
+
+    it('locates the next unit via the O(1) fast-path from the prior hint', () => {
+        // last=0 (unit 1 was active); t is inside unit 2 — the [last, last+1]
+        // fast-path should return it without falling back to bsearch.
+        const hit = findActiveAt(units, sorted, 1.5, 0);
+        expect(hit).toEqual({ unitIdx: 1, ivStart: 1, ivEnd: 2 });
+    });
+
+    it('returns null in a mid-recitation silence gap', () => {
+        // [2,3) is a gap between unit 2 (ends 2) and unit 3 (starts 3).
+        expect(findActiveAt(units, sorted, 2.5, 1)).toBeNull();
+    });
+
+    it('returns null before the first interval (leading silence)', () => {
+        expect(findActiveAt(units, sorted, -0.5, -1)).toBeNull();
+    });
+
+    it('returns null after the last interval (trailing silence)', () => {
+        expect(findActiveAt(units, sorted, 9, 2)).toBeNull();
+    });
+
+    it('travels back to an earlier verse on a loopback via bsearch fallback', () => {
+        // Reading order A,B; A is repeated AFTER B. The forward hint points at B,
+        // so the fast-path misses and bsearch must find A's later occurrence.
+        const loop = [
+            unit('1:1:1', [[0, 1], [4, 5]]),
+            unit('1:1:2', [[1, 2]]),
+        ];
+        const loopSorted = buildSortedIntervals(loop);
+        const hit = findActiveAt(loop, loopSorted, 4.5, 1);
+        expect(hit).toEqual({ unitIdx: 0, ivStart: 4, ivEnd: 5 });
+    });
+
+    it('selects the occurrence interval that contains the time on a repeat', () => {
+        const repeated = [unit('1:1:1', [[0, 1], [5, 6]])];
+        const repeatedSorted = buildSortedIntervals(repeated);
+        const hit = findActiveAt(repeated, repeatedSorted, 5.4, -1);
+        expect(hit).toEqual({ unitIdx: 0, ivStart: 5, ivEnd: 6 });
+    });
+
+    it('returns null for no units', () => {
+        expect(findActiveAt([], [], 1, -1)).toBeNull();
+    });
+});

--- a/inspector/frontend/src/lib/recitation-animation/filmstrip-model.ts
+++ b/inspector/frontend/src/lib/recitation-animation/filmstrip-model.ts
@@ -1,0 +1,131 @@
+/**
+ * Filmstrip cell model — recitation-correct geometry + per-verse word fractions.
+ *
+ * The ayah filmstrip is a verse ruler driven by the actual recitation. This
+ * derives, from the chapter's deduped `units`, one `VerseCell` per ayah (in
+ * reading order) carrying:
+ *   - `canonDurSec` — the verse's canonical recited length (sum of each word's
+ *     FIRST-occurrence duration), used to SIZE the cell. Never inflated by a
+ *     loopback's later occurrence (unlike `AyahBoundary.endMs = max(end)`).
+ *   - `words` — a fraction table: each word's `[frac0, frac1)` position within
+ *     the verse, so the active cell's progress bar fills to the recited WORD's
+ *     position (and loops back proportionally on a within-verse repeat) instead
+ *     of growing with elapsed clock time.
+ *
+ * Plus reverse lookups (`indexByAyahKey`, `cellOfUnit`) so the playback loop can
+ * go active-unit → cell in O(1). Built once per chapter. Pure; no fetch/tab
+ * imports. Times are seconds (matching `AnimUnit`).
+ */
+
+import { ayahUnitRanges } from './chapter-words';
+import type { AnimUnit } from './types';
+
+/** Weighting for a word's share of its verse's progress bar.
+ *  `duration` (default) = canonical word length; `equal` = one slot per word. */
+export type WordWeighting = 'duration' | 'equal';
+
+/** A word's position within its verse, as a half-open fraction range. */
+export interface WordFrac {
+    /** Global index into `units`. */
+    unitIdx: number;
+    /** Word index within the ayah (1-based, from the shard). */
+    word: number;
+    frac0: number;
+    frac1: number;
+}
+
+/** One verse cell — geometry source + word-fraction table. */
+export interface VerseCell {
+    ayahKey: string;
+    surah: number;
+    ayah: number;
+    /** Canonical recited duration (seconds) — sum of word first-occurrence
+     *  durations. Drives cell WIDTH regardless of `weighting`. */
+    canonDurSec: number;
+    /** [start, end) global unit-index range for the verse (reading order). */
+    unitStart: number;
+    unitEnd: number;
+    /** Word-fraction table, ordered by word (= reading order within the verse). */
+    words: WordFrac[];
+    /** Canonical first-occurrence start (seconds) — the click/drag seek target. */
+    canonStartSec: number;
+}
+
+export interface FilmstripModel {
+    cells: VerseCell[];
+    /** ayahKey → cell index. */
+    indexByAyahKey: Map<string, number>;
+    /** Global unitIdx → cell index (−1 for none, though every unit maps). */
+    cellOfUnit: Int32Array;
+}
+
+const EMPTY_MODEL: FilmstripModel = {
+    cells: [],
+    indexByAyahKey: new Map(),
+    cellOfUnit: new Int32Array(0),
+};
+
+/** Each word's canonical duration = its FIRST occurrence's span (seconds). A
+ *  repeat re-emits the word with a new interval, but the first is the canonical
+ *  reading-order length; `>= eps` so a zero-length word still gets a slot. */
+function canonDur(u: AnimUnit): number {
+    const iv = u.intervals[0];
+    if (!iv) return 0.001;
+    return Math.max(0.001, iv.end - iv.start);
+}
+
+/**
+ * Build the filmstrip cell model from the chapter's deduped units.
+ *
+ * @param units    deduped `AnimUnit[]` in reading order (from `buildChapterRecitation`)
+ * @param weighting word-fraction weighting (`duration` default, `equal` swappable)
+ */
+export function buildFilmstripModel(
+    units: AnimUnit[],
+    weighting: WordWeighting,
+): FilmstripModel {
+    if (!units.length) return EMPTY_MODEL;
+
+    const cells: VerseCell[] = [];
+    const indexByAyahKey = new Map<string, number>();
+    const cellOfUnit = new Int32Array(units.length).fill(-1);
+
+    // `ayahUnitRanges` preserves reading order and assumes each ayah's units are
+    // contiguous (true for the deduped reading-order list).
+    for (const [ayahKey, [unitStart, unitEnd]] of ayahUnitRanges(units)) {
+        const head = units[unitStart]!;
+        let canonDurSec = 0;
+        let total = 0;
+        for (let i = unitStart; i < unitEnd; i++) {
+            const d = canonDur(units[i]!);
+            canonDurSec += d;
+            total += weighting === 'equal' ? 1 : d;
+        }
+        if (total <= 0) total = 1; // degenerate guard (all-zero weights)
+
+        const words: WordFrac[] = [];
+        let cum = 0;
+        for (let i = unitStart; i < unitEnd; i++) {
+            const u = units[i]!;
+            const wgt = weighting === 'equal' ? 1 : canonDur(u);
+            const frac0 = cum / total;
+            cum += wgt;
+            words.push({ unitIdx: i, word: u.word, frac0, frac1: cum / total });
+            cellOfUnit[i] = cells.length;
+        }
+
+        indexByAyahKey.set(ayahKey, cells.length);
+        cells.push({
+            ayahKey,
+            surah: head.surah,
+            ayah: head.ayah,
+            canonDurSec,
+            unitStart,
+            unitEnd,
+            words,
+            canonStartSec: head.intervals[0]?.start ?? head.start,
+        });
+    }
+
+    return { cells, indexByAyahKey, cellOfUnit };
+}

--- a/inspector/frontend/src/lib/recitation-animation/index.ts
+++ b/inspector/frontend/src/lib/recitation-animation/index.ts
@@ -24,6 +24,19 @@ export {
     type Granularity,
     type RecitationAnimConfig,
 } from './config';
+export {
+    buildSortedIntervals,
+    findActiveAt,
+    type ActiveHit,
+    type SortedInterval,
+} from './recitation-active';
+export {
+    buildFilmstripModel,
+    type FilmstripModel,
+    type VerseCell,
+    type WordFrac,
+    type WordWeighting,
+} from './filmstrip-model';
 export type {
     AnimUnit,
     AyahBoundary,

--- a/inspector/frontend/src/lib/recitation-animation/recitation-active.ts
+++ b/inspector/frontend/src/lib/recitation-animation/recitation-active.ts
@@ -1,0 +1,94 @@
+/**
+ * Recitation timeline — the shared "which word is recited at time t" locator.
+ *
+ * Both the teleprompter line (`LineAnimation`) and the ayah filmstrip
+ * (`AyahFilmstrip`) drive themselves off the actual recitation rather than a
+ * monotonic clock, so they must agree on the active unit. This module owns that
+ * mapping: a flat, sorted-by-start list of every occurrence interval across all
+ * units, plus a stateful active-unit lookup that handles forward playback
+ * (O(1)), seek-back, silence gaps, and repeats/look-backs (O(log n) bsearch).
+ *
+ * Pure + unit-agnostic: `t` and the interval bounds are in whatever unit the
+ * caller's `AnimUnit.intervals` use (seconds in `types.ts`). No module state —
+ * the O(1) fast-path hint is threaded through the `last` parameter.
+ */
+
+import type { AnimUnit } from './types';
+
+/** One occurrence interval, tagged with its owning unit's global index. */
+export interface SortedInterval {
+    start: number;
+    end: number;
+    unitIdx: number;
+}
+
+/** A located active unit + the occurrence interval containing the query time.
+ *  (Char-level sweeps need the interval bounds to remap repeats.) */
+export interface ActiveHit {
+    unitIdx: number;
+    ivStart: number;
+    ivEnd: number;
+}
+
+/**
+ * Flatten every occurrence interval across all units, sorted ascending by
+ * start. Each `units[i]` has ≥1 ascending intervals; reading order is normally
+ * also temporal order, but repeats can interleave — so we sort defensively.
+ * Built once per chapter.
+ */
+export function buildSortedIntervals(units: AnimUnit[]): SortedInterval[] {
+    const out: SortedInterval[] = [];
+    for (let i = 0; i < units.length; i++) {
+        const u = units[i]!;
+        for (const iv of u.intervals) {
+            out.push({ start: iv.start, end: iv.end, unitIdx: i });
+        }
+    }
+    out.sort((a, b) => a.start - b.start);
+    return out;
+}
+
+/**
+ * Locate the unit active at time `t`, with an O(1) fast-path and an O(log n)
+ * bsearch fallback. `last` is the caller's previous active `unitIdx` (or -1 for
+ * a random-access query with no useful hint) — the fast-path tries `last` and
+ * `last + 1`, covering forward playback without a search.
+ *
+ * Returns the hit (unit index + the occurrence interval containing `t`), or
+ * `null` during a silence gap (before the first interval, after the last, or in
+ * a pause between occurrences).
+ */
+export function findActiveAt(
+    units: AnimUnit[],
+    sorted: SortedInterval[],
+    t: number,
+    last: number,
+): ActiveHit | null {
+    const n = units.length;
+    if (n === 0) return null;
+    // Fast path: same unit as last frame, or the next unit. Covers the common
+    // forward-playback case in O(1) — no allocation, no bsearch.
+    for (const cand of [last, last + 1]) {
+        if (cand < 0 || cand >= n) continue;
+        const u = units[cand]!;
+        for (const iv of u.intervals) {
+            if (t >= iv.start && t < iv.end) {
+                return { unitIdx: cand, ivStart: iv.start, ivEnd: iv.end };
+            }
+        }
+    }
+    // Fallback: bsearch the flat sorted interval list. Handles seek-back,
+    // silence gaps, and repeats where a later reading-order unit's first
+    // occurrence has not yet started but an earlier unit's repeat has.
+    if (sorted.length === 0 || t < sorted[0]!.start) return null;
+    let lo = 0;
+    let hi = sorted.length - 1;
+    while (lo < hi) {
+        const mid = (lo + hi + 1) >> 1;
+        if (sorted[mid]!.start <= t) lo = mid;
+        else hi = mid - 1;
+    }
+    const iv = sorted[lo]!;
+    if (t < iv.end) return { unitIdx: iv.unitIdx, ivStart: iv.start, ivEnd: iv.end };
+    return null;
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -35,6 +35,7 @@ no-op-or-error by design. Idempotent `backfill_*`/`purge_*`/`convert_*` stay in
 - `smoke_boot.py` — build the image, boot it on fixtures, assert `/healthz` (CI boot gate)
 
 ### `devenv/`
+- `setup.sh` — first-time local setup: install FE (`npm ci`) + BE (`pip`) deps so tests/build/lint run (`frontend`/`backend` to scope). Idempotent.
 - `bootstrap_dev_env.py` — provision a contributor's personal bucket + Space
 - `seed_fixtures.py` — download the public fixtures → `.fixtures` (offline tier-0)
 - `make_fixtures_dataset.py` — maintainer: (re)build the PII-free public fixtures dataset

--- a/scripts/devenv/setup.sh
+++ b/scripts/devenv/setup.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# First-time local setup — install the toolchain deps so the tests, typecheck,
+# lint, and build run. Idempotent: safe to re-run. The dev/CI container is
+# ephemeral (fresh clone, no node_modules / site-packages), so run this once per
+# checkout before `npm run test` or pytest.
+#
+#   scripts/devenv/setup.sh             # frontend + backend (default)
+#   scripts/devenv/setup.sh frontend    # just the FE (npm) deps
+#   scripts/devenv/setup.sh backend     # just the BE (pip) deps
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+target="${1:-all}"
+
+setup_frontend() {
+    echo "==> Frontend deps (inspector/frontend): npm ci"
+    # `npm ci` installs EXACTLY the lockfile versions (vitest 3.x, vite 5, the
+    # svelte plugin) — unlike `npm install`, which can drift. Afterwards use the
+    # repo's pinned scripts: `npm run test` / check / lint / build, NOT
+    # `npx vitest` or `npm exec -- vitest` (those can resolve a mismatched global
+    # vitest that fails to transform .svelte files).
+    npm --prefix "$ROOT/inspector/frontend" ci
+}
+
+setup_backend() {
+    echo "==> Backend deps (inspector): pip install requirements + dev"
+    local reqs=(-r "$ROOT/inspector/requirements.txt" -r "$ROOT/inspector/requirements-dev.txt")
+    if ! python3 -m pip install "${reqs[@]}"; then
+        # Some base images ship distro-managed packages (e.g. debian's blinker)
+        # that pip can't uninstall to satisfy a version bump ("RECORD file not
+        # found"). --ignore-installed installs fresh copies that shadow them.
+        echo "   pip conflict (distro-managed package?); retrying --ignore-installed ..."
+        python3 -m pip install --ignore-installed "${reqs[@]}"
+    fi
+}
+
+case "$target" in
+    all)         setup_frontend; setup_backend ;;
+    frontend|fe) setup_frontend ;;
+    backend|be)  setup_backend ;;
+    *) echo "usage: setup.sh [all|frontend|backend]" >&2; exit 2 ;;
+esac
+
+cat <<'EOF'
+
+Setup complete. Run with the PINNED scripts (not npx / npm exec):
+  cd inspector/frontend && npm run test    # vitest — also: npm run check / lint / build
+  cd inspector && python -m pytest tests/ -v
+EOF


### PR DESCRIPTION
## What & why

The Verz filmstrip (the by-ayah scrubber above the bottom player, shared by **both** the Dashboard and Timestamps tabs) was **purely clock-driven**: it bucketed a monotonic audio clock into canonical ayah cells and filled the active cell with *elapsed time*. Real recitation isn't linear — it has **silences** (leading/trailing margins + mid-recitation pauses) and **loopbacks** (the reciter repeats words or whole verses, so audio time moves forward while the recited position moves backward). The old model couldn't express any of that, and for reciters who repeat verses the canonical `ayahs` boundaries (`min start` / `max end`) **overlapped and inflated cell widths**, subtly breaking the lookup.

This PR has two parts.

### Part 1 — Recitation-driven filmstrip (`a4ff508`)

Makes the filmstrip follow the **actual recitation**, realizing the documented intent that loopback occasions are retained in the bucket *"for the filmstrip"* (`timestamps-job.md` §1a). Behavior, in both `snap` and `hybrid` modes:

- **Silence freeze** — during any silence the active cell **de-highlights**, the cursor/needle **hide**, the strip **stops**, and the cell bar **freezes** at its last value; it resumes exactly when speech regenerates. The cell bar measures **speech time only**.
- **Within-verse word loopback** — when earlier words are repeated, the cell bar **rewinds proportionally** (duration-weighted by each word's canonical length).
- **Cross-verse loopback** — going back a verse or two **scrolls the strip back** to it, positioned at the word reached.
- The bottom **`PlayerProgress` scrubber stays time-linear** — only the cell bar is recitation-adaptive.

**How:** extracted `LineAnimation`'s proven `findActiveAt` timeline into a shared, pure `recitation-active.ts` (`buildSortedIntervals` + `findActiveAt`); `LineAnimation` now consumes it (behavior-identical — its existing test stays green). `filmstrip-model.ts` builds loopback-correct cell widths (canonical first-occurrence duration, never inflated) + a per-verse duration-weighted word-fraction table. `AyahFilmstrip.svelte` inverts its driver: active cell + fill come from "which word is recited at time *t*". Also fixes the latent inflated/overlapping cell widths for reciters who repeat verses.

### Part 2 — Unified, distance-proportional scroll glide (`d6c0253`)

The scroll *motion* was inconsistent: only `snap` mode auto-glided (a fixed 560ms ease-out that started abruptly and felt the same whether the target was one cell or the far end), while `hybrid` jumps and linear-scrubber seeks teleported.

- Replaced the fixed CSS transition with **one JS rAF tween** (`glideTo`) whose **duration scales with scroll distance** + ease-in-out, so a one-cell hop and a scroll to the end of the strip feel like the same motion, just longer.
- Every deliberate scroll now routes through it in **both modes**: cell click, keyboard, snap verse-center, recitation loopbacks, paused re-sync — and **newly the linear progress-bar seeks** (detected via a per-frame audio-time jump; no change to `PlayerProgress`).
- The cell-fill rewind ease is **decoupled** from the strip scroll so normal forward play never lags the bar; the two share one duration. `prefers-reduced-motion` → instant.

## Tests

- New unit tests for `recitation-active` (fast-path, silence gaps pre/mid/post, loopback bsearch fallback, repeat-occurrence selection) and `filmstrip-model` (non-inflated widths, duration vs equal weighting, unit→cell maps, empty input).
- Full FE suite green (568 tests), `npm run check` + `npm run lint` clean, production build OK.

## Verification

`npm run dev`, pick a published **by_surah** reciter that repeats verses, watch the strip in both tabs / both motion modes: pauses freeze the cell + hide the cursor; word repeats rewind the bar; a verse loopback scrolls back; the bottom scrubber keeps advancing linearly throughout. For the glide: click a near vs far verse (proportional duration, soft start/stop), click the linear bar at a far spot (the strip smoothly scrolls there, not a teleport), and a full-strip seek reads as a smooth linear scroll-through. Glide velocity is tunable via `GLIDE_MS_PER_PX` / `GLIDE_MIN_MS` / `GLIDE_MAX_MS` in `AyahFilmstrip.svelte`.