### PR TITLE
fix(board-fe): filmstrip scroll tracks live recited position (#143 loopback desync)

### DIFF
--- a/inspector/frontend/src/lib/recitation-animation/AyahFilmstrip.svelte
+++ b/inspector/frontend/src/lib/recitation-animation/AyahFilmstrip.svelte
@@ -15,15 +15,21 @@
      *   - snap:   center the active cell only when the ayah changes; drag = snap.
      *
      * User scrub/drag/click stays TIME-based (seeking); playback is the only
-     * recitation-driven path. Every deliberate scroll (click, key, snap-center,
-     * loopback, linear-bar seek) runs through ONE JS tween (`glideTo`) with
-     * distance-proportional duration + ease-in-out, so a one-cell hop and a
-     * scroll to the far end of the strip feel like the same motion. Live drag
-     * and hybrid playback tracking write `offset` directly. Surface-agnostic:
-     * fed `units` + a prebuilt `FilmstripModel` + a time accessor + an onSeek cb.
+     * recitation-driven path. Scroll moves split by kind so they never fight:
+     *   - Continuous playback (hybrid/tuner) tracks the LIVE recited position
+     *     each frame via `stepScroll` — instant in forward play, and on a
+     *     loopback/seek a per-frame catch-up that chases the still-moving target
+     *     (never freezes on a stale snapshot). Scroll, fill and audio stay locked.
+     *   - Discrete moves to a FIXED point (snap-center, click, key, drag-release,
+     *     paused refresh) run through ONE JS tween (`glideTo`) with distance-
+     *     proportional duration + ease-in-out, so a one-cell hop and a far scroll
+     *     feel like the same motion. Live drag writes `offset` directly.
+     * Surface-agnostic: fed `units` + a prebuilt `FilmstripModel` + a time
+     * accessor + an onSeek cb.
      */
     import { type RecitationAnimConfig } from './config';
     import type { FilmstripModel } from './filmstrip-model';
+    import { stepScroll } from './filmstrip-scroll';
     import { buildSortedIntervals, findActiveAt } from './recitation-active';
     import type { AnimUnit } from './types';
 
@@ -84,13 +90,17 @@
     let silent = $state(false); // in a silence gap → frozen, no highlight/cursor
     let frozenIdx = $state(-1); // last active cell, held while silent
     let jumping = $state(false); // mid-glide → cell-fill eases too
+    let following = false; // continuous mode: smoothing offset toward live target
+    let followTarget = 0; // last catch-up target — feeds stepScroll's velocity landing
     let lastActiveUnit = -1; // O(1) fast-path hint for findActiveAt
     let lastTimeMs = -1; // previous frame's audio time, for seek detection
     let fillGlideTimer: ReturnType<typeof setTimeout> | null = null;
 
-    // JS scroll tween — the single source of animated `offset` moves. Distance-
-    // proportional duration + soft ease, so a one-cell hop and a scroll to the
-    // far end of the strip feel like the same motion, just longer.
+    // JS scroll tween for DISCRETE moves to a fixed point (snap-center, click,
+    // key, drag-release, paused refresh). Distance-proportional duration + soft
+    // ease, so a one-cell hop and a far scroll feel like the same motion, just
+    // longer. Continuous playback tracking does NOT use this (it would snapshot a
+    // stale target); it tracks the live position via `stepScroll` instead.
     interface Tween { from: number; to: number; startT: number; dur: number; }
     let tween: Tween | null = null;
     let tweenRaf = 0;
@@ -239,16 +249,30 @@
         tween = null;
         if (tweenRaf) cancelAnimationFrame(tweenRaf);
         tweenRaf = 0;
+        following = false; // drop any continuous catch-up too
+        followTarget = 0;
     }
-    /** Ease the active cell's fill bar over `dur` (a loopback rewind or a seek),
-     *  matched to the strip glide. Off for normal forward play (the bar tracks
-     *  per-frame with no transition, so it can't lag). */
+    /** Ease the active cell's fill bar across a SINGLE loopback/seek rewind, then
+     *  drop the transition so subsequent forward frames track instantly. The
+     *  transition is short and one-shot — holding it across the whole glide would
+     *  make every per-frame `setFill` chase a moving target and visibly lag the
+     *  audio (the fill would crawl, never catching up). */
     function armFillGlide(dur: number): void {
         if (reducedMotion) return;
         containerEl?.style.setProperty('--cell-glide-dur', dur + 'ms');
         jumping = true;
         if (fillGlideTimer) clearTimeout(fillGlideTimer);
+        // One eased step is ~one transition; clear once it has landed so forward
+        // play is instant again. `disarmFillGlide` also clears it on the next
+        // non-jump frame, whichever comes first.
         fillGlideTimer = setTimeout(() => { jumping = false; }, dur);
+    }
+    /** Drop the eased-fill transition the moment forward tracking resumes, so a
+     *  loopback's eased rewind never bleeds into the live per-frame fill. */
+    function disarmFillGlide(): void {
+        if (!jumping) return;
+        jumping = false;
+        if (fillGlideTimer) { clearTimeout(fillGlideTimer); fillGlideTimer = null; }
     }
     /** A discrete strip move (loopback / seek / user nav): glide the strip AND
      *  ease the fill over the same distance-proportional time. */
@@ -293,17 +317,30 @@
 
         const snap = config.filmstripMotion === 'snap';
         const target = snap ? offsetForCellCenter(r.idx) : offsetForReci(r);
-        if (discont) {
-            jumpTo(target); // loopback / seek → glide strip + ease bar
-            return;
-        }
+
         if (snap) {
-            // Smooth forward play: center the new verse on each ayah change.
-            if (r.idx !== prevIdx) glideTo(target);
+            // Snap centers the active cell — a fixed point, not a moving one, so
+            // a one-shot glide is correct. Loopback/seek eases the fill too.
+            if (discont) jumpTo(target);
+            else { disarmFillGlide(); if (r.idx !== prevIdx) glideTo(target); }
             return;
         }
-        if (tween) return; // a glide is still settling — let it own offset
-        offset = target; // hybrid/tuner continuous tracking
+
+        // Hybrid/tuner continuously center the LIVE recited position. `stepScroll`
+        // tracks it instantly in forward play, and on a loopback/seek arms a
+        // smooth catch-up that chases the moving target (never a stale snapshot),
+        // so scroll, fill and audio stay locked together. A discontinuity also
+        // eases the fill once.
+        if (discont) armFillGlide(GLIDE_MIN_MS);
+        else disarmFillGlide();
+        const wasFollowing = following;
+        if (tween) cancelTween(); // a paused-refresh glide can't co-own offset
+        const s = stepScroll(
+            offset, target, discont, wasFollowing, followTarget, lastRight, reducedMotion,
+        );
+        offset = s.offset;
+        following = s.following;
+        followTarget = s.prevTarget;
     }
 
     // rAF while playing: drive the recitation mapping (all modes).

--- a/inspector/frontend/src/lib/recitation-animation/__tests__/AyahFilmstrip.loopback.test.ts
+++ b/inspector/frontend/src/lib/recitation-animation/__tests__/AyahFilmstrip.loopback.test.ts
@@ -1,0 +1,165 @@
+import { render } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AyahFilmstrip from '../AyahFilmstrip.svelte';
+import { DEFAULT_RECITATION_CONFIG } from '../config';
+import { buildFilmstripModel } from '../filmstrip-model';
+import type { AnimUnit, TimeSpan } from '../types';
+
+/**
+ * Component-level guard for the recitation-driven filmstrip loopback.
+ *
+ * Two regressions are covered:
+ *   1. The active cell + fill must travel BACK to the looped verse and re-light it
+ *      — never stay stuck/frozen on the later verse "as if pausing like silence".
+ *   2. The STRIP SCROLL must track the re-recited word through the WHOLE replay
+ *      window, not just the jump moment. The earlier fixed-fraction catch-up
+ *      settled at a constant lag against the still-moving target, so the strip
+ *      trailed the audio (sitting in the wrong cell's region) for the entire
+ *      loopback and only realigned once linear forward play resumed. The
+ *      velocity-aware landing must keep the offset on the live recited position.
+ *
+ * (The pure per-frame scroll stepper is unit-tested in `filmstrip-scroll.test.ts`.)
+ */
+
+function unit(loc: string, ivs: Array<[number, number]>): AnimUnit {
+    const [s, a, w] = loc.split(':').map(Number);
+    const spans: TimeSpan[] = ivs.map(([st, en]) => ({ start: st, end: en }));
+    return {
+        location: loc, ayahKey: `${s}:${a}`, surah: s!, ayah: a!, word: w!, text: loc,
+        start: spans[0]!.start, end: spans[spans.length - 1]!.end, intervals: spans, letters: [],
+    };
+}
+
+// v1 (2 words) · v2 (2 words, RECITED then LOOPED BACK at 6-8s) · v3 (2 words).
+const units: AnimUnit[] = [
+    unit('1:1:1', [[0, 1]]),
+    unit('1:1:2', [[1, 2]]),
+    unit('1:2:1', [[2, 3], [6, 7]]),
+    unit('1:2:2', [[3, 4], [7, 8]]),
+    unit('1:3:1', [[4, 5]]),
+    unit('1:3:2', [[5, 6]]),
+];
+const model = buildFilmstripModel(units, 'duration');
+
+function activeCellAyah(container: HTMLElement): number | null {
+    const el = container.querySelector<HTMLElement>('.cell.active .cell-num');
+    return el ? Number(el.textContent) : null;
+}
+function frozenCellAyah(container: HTMLElement): number | null {
+    const el = container.querySelector<HTMLElement>('.cell.frozen .cell-num');
+    return el ? Number(el.textContent) : null;
+}
+/** Current strip scroll offset (px) — the negated track translateX. */
+function scrollOffset(container: HTMLElement): number {
+    const el = container.querySelector<HTMLElement>('.track');
+    const m = el ? /translateX\((-?[\d.]+)px\)/.exec(el.style.transform) : null;
+    return m ? -parseFloat(m[1]!) : 0;
+}
+/** Each cell's [left, right] px span (cumBefore … cumBefore+width), gap-aware —
+ *  so a test can assert the offset sits within a given verse's region. */
+function cellSpans(container: HTMLElement, gapPx: number): Array<[number, number]> {
+    const out: Array<[number, number]> = [];
+    let cum = 0;
+    for (const el of container.querySelectorAll<HTMLElement>('.cell')) {
+        const w = parseFloat(el.style.width);
+        out.push([cum, cum + w]);
+        cum += w + gapPx;
+    }
+    return out;
+}
+
+describe('AyahFilmstrip loopback (recitation-driven)', () => {
+    // Manual rAF + clock so the playback loop can be stepped frame-by-frame.
+    let rafCbs: FrameRequestCallback[] = [];
+    let nowMs = 0;
+    const getTimeMs = (): number => nowMs;
+
+    beforeEach(() => {
+        rafCbs = [];
+        vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback): number => {
+            rafCbs.push(cb);
+            return rafCbs.length;
+        });
+        vi.stubGlobal('cancelAnimationFrame', () => {});
+        vi.spyOn(performance, 'now').mockImplementation(() => nowMs);
+    });
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    /** Advance the audio clock to `toMs` and run the rAF loop to steady state for
+     *  this frame. The playback loop re-queues itself each pump; draining the
+     *  re-queued callback makes the offset reflect THIS frame's recited target
+     *  (one pump would leave it a frame behind — the manual-clock analogue of the
+     *  browser running exactly one rAF per displayed frame). */
+    async function step(toMs: number): Promise<void> {
+        nowMs = toMs;
+        for (let i = 0; i < 2 && rafCbs.length; i++) {
+            const batch = rafCbs;
+            rafCbs = [];
+            for (const cb of batch) cb(nowMs);
+            await tick();
+        }
+    }
+
+    it('travels the active cell back to the looped verse, never stuck/frozen', async () => {
+        const { container } = render(AyahFilmstrip, {
+            units, model, durationMs: 8000, getTimeMs, playing: true,
+            config: { ...DEFAULT_RECITATION_CONFIG, filmstripMotion: 'hybrid' },
+            onSeek: () => {},
+        });
+        await tick();
+
+        // Forward play through verse 3 (later in the chapter).
+        for (const ms of [500, 1500, 2500, 3500, 4500, 5500]) await step(ms);
+        expect(activeCellAyah(container)).toBe(3);
+
+        // Loopback: audio re-enters verse 2 (occurrence at 6-8s). The active cell
+        // must travel BACK to verse 2 — not freeze on verse 3 or go silent.
+        for (const ms of [6200, 6600, 7000]) await step(ms);
+        expect(frozenCellAyah(container)).toBeNull(); // not stuck-as-silence
+        expect(activeCellAyah(container)).toBe(2);
+    });
+
+    it('travels the strip scroll into the looped verse and tracks the re-recited word', async () => {
+        const { container } = render(AyahFilmstrip, {
+            units, model, durationMs: 8000, getTimeMs, playing: true,
+            config: { ...DEFAULT_RECITATION_CONFIG, filmstripMotion: 'hybrid' },
+            onSeek: () => {},
+        });
+        await tick();
+
+        const gap = DEFAULT_RECITATION_CONFIG.filmstripGapPx;
+        const spans = cellSpans(container, gap); // [left,right] px per cell
+        const [v2Left, v2Right] = spans[1]!; // verse 2 cell region
+
+        // Forward play to verse 3, then loop back to verse 2 (occurrence at 6-8s).
+        for (const ms of [500, 1500, 2500, 3500, 4500, 5500]) await step(ms);
+        const beforeLoop = scrollOffset(container);
+        expect(beforeLoop).toBeGreaterThan(v2Right); // sitting past verse 2, on verse 3
+
+        // Sample every frame across the replay. The strip must travel BACK into
+        // verse 2's region and advance forward through it as the re-recited word
+        // progresses. The earlier fixed-fraction catch-up trailed by a constant lag,
+        // so it never reached verse 2 — it lingered at/past v2Right (on verse 3) for
+        // the whole replay and only realigned after linear play resumed.
+        const offs: number[] = [];
+        for (let ms = 6050; ms <= 7950; ms += 100) {
+            await step(ms);
+            offs.push(scrollOffset(container));
+        }
+
+        // Lands inside verse 2 within a couple of frames and STAYS there.
+        const landed = offs.slice(2);
+        for (const off of landed) {
+            expect(off).toBeGreaterThanOrEqual(v2Left - 2); // in verse 2…
+            expect(off).toBeLessThanOrEqual(v2Right + 2); // …not drifted into verse 3
+            expect(off).toBeLessThan(beforeLoop); // travelled back from the loop point
+        }
+        // …advancing monotonically as the replayed word progresses (never frozen).
+        expect(landed[landed.length - 1]!).toBeGreaterThan(landed[0]! + 20);
+    });
+});

--- a/inspector/frontend/src/lib/recitation-animation/__tests__/filmstrip-scroll.test.ts
+++ b/inspector/frontend/src/lib/recitation-animation/__tests__/filmstrip-scroll.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import { GLIDE_FOLLOW, type ScrollState, stepScroll } from '../filmstrip-scroll';
+
+/** Seed for the arm frame (no prior catch-up target). */
+const armed = (offset: number): ScrollState => ({ offset, following: false, prevTarget: 0 });
+
+describe('stepScroll forward tracking', () => {
+    it('tracks the live target instantly when not in a catch-up', () => {
+        // No discontinuity, not following → the needle sits exactly on the target
+        // (scroll, fill and audio stay locked). This is the per-frame forward case.
+        const s = stepScroll(100, 137, false, false, 0, 1000, false);
+        expect(s.offset).toBe(137);
+        expect(s.following).toBe(false);
+    });
+
+    it('keeps tracking instantly across consecutive forward frames', () => {
+        let st = armed(0);
+        for (const target of [10, 22, 35, 49]) {
+            st = stepScroll(st.offset, target, false, false, st.prevTarget, 1000, false);
+            expect(st.offset).toBe(target); // never lags the live position
+        }
+    });
+});
+
+describe('stepScroll loopback catch-up', () => {
+    it('eases toward the target on a discontinuity instead of jumping', () => {
+        // Loopback: target is BEHIND the current offset (an earlier verse). One
+        // frame closes GLIDE_FOLLOW of the gap — a smooth rewind, not a teleport.
+        const s = stepScroll(500, 100, true, false, 0, 1000, false);
+        expect(s.following).toBe(true);
+        expect(s.offset).toBeCloseTo(500 + (100 - 500) * GLIDE_FOLLOW, 6);
+        expect(s.offset).toBeLessThan(500); // moved toward the looped verse
+        expect(s.offset).toBeGreaterThan(100); // but eased, not snapped
+    });
+
+    it('lands ON a MOVING target during replay — converges to zero lag', () => {
+        // After the loopback the recited word keeps advancing. A fixed-fraction
+        // smoothing toward a moving target would settle at a CONSTANT lag and never
+        // land; the velocity-aware landing must close that lag to zero and hand
+        // back to instant tracking so the strip sits exactly on the replayed word.
+        let st = stepScroll(500, 100, true, false, 0, 1000, false); // arm at snapshot 100
+        let liveTarget = 100;
+        for (let i = 0; i < 30; i++) {
+            liveTarget += 4; // verse replays forward, ~4px/frame
+            st = stepScroll(st.offset, liveTarget, false, st.following, st.prevTarget, 1000, false);
+        }
+        // Converged exactly onto the live position, NOT trailing by a fixed lag.
+        expect(st.following).toBe(false);
+        expect(st.offset).toBe(liveTarget);
+    });
+
+    it('moves every frame during the catch-up (never frozen)', () => {
+        let st = stepScroll(500, 100, true, false, 0, 1000, false);
+        let liveTarget = 100;
+        let prev = st.offset;
+        // Sample the catch-up transient (before it lands): each frame must move.
+        for (let i = 0; i < 4; i++) {
+            liveTarget += 4;
+            st = stepScroll(st.offset, liveTarget, false, st.following, st.prevTarget, 1000, false);
+            expect(st.offset).not.toBe(prev);
+            prev = st.offset;
+        }
+    });
+
+    it('lands and resumes instant tracking once within snap distance', () => {
+        // Static target (velocity 0): land at the base SNAP_EPS_PX.
+        const s = stepScroll(100.4, 100, false, true, 100, 1000, false);
+        expect(s.offset).toBe(100);
+        expect(s.following).toBe(false);
+    });
+
+    it('jumps straight to the target under reduced motion', () => {
+        const s = stepScroll(500, 100, true, false, 0, 1000, true);
+        expect(s.offset).toBe(100);
+        expect(s.following).toBe(false);
+    });
+
+    it('clamps the target into [0, lastRight]', () => {
+        expect(stepScroll(0, 1e6, false, false, 0, 250, false).offset).toBe(250);
+        expect(stepScroll(0, -50, false, false, 0, 250, false).offset).toBe(0);
+    });
+});

--- a/inspector/frontend/src/lib/recitation-animation/filmstrip-scroll.ts
+++ b/inspector/frontend/src/lib/recitation-animation/filmstrip-scroll.ts
@@ -1,0 +1,76 @@
+/**
+ * Filmstrip continuous-scroll stepper — the per-frame `offset` decision for the
+ * hybrid/tuner motion models, factored out of `AyahFilmstrip` so it is testable
+ * in isolation (the component itself is rAF/canvas-imperative).
+ *
+ * Forward playback tracks the live recited position INSTANTLY (the needle sits
+ * exactly on the recited word). A loopback or seek arms a smooth catch-up: each
+ * frame closes a fixed fraction of the gap toward the LIVE (still-moving) target
+ * via exponential smoothing — so the strip chases the advancing position instead
+ * of teleporting.
+ *
+ * The catch-up exists only to absorb the JUMP distance; the recited target keeps
+ * moving during a replay, so a fixed-fraction smoothing alone would converge to a
+ * constant lag (and never land), trailing the audio for the whole loopback. So
+ * the landing test is velocity-aware: once the offset is within one frame's-worth
+ * of the target's own motion (`SNAP_EPS_PX` + |Δtarget|), the catch-up is in
+ * lockstep — snap onto the live target and resume instant tracking. `prevTarget`
+ * (threaded through `ScrollState`) supplies that per-frame target velocity.
+ *
+ * Pure: no DOM, no rAF, no module state — `following`/`prevTarget` are threaded.
+ */
+
+/** Per-frame catch-up fraction during a loopback/seek glide (higher = snappier;
+ *  ~0.28 absorbs a within-verse rewind in ~5 frames then lands in lockstep). */
+export const GLIDE_FOLLOW = 0.28;
+/** Base distance (px) under which the catch-up is "landed". The live landing
+ *  threshold adds the target's per-frame motion so a moving target still lands. */
+export const SNAP_EPS_PX = 1;
+
+export interface ScrollState {
+    /** New strip offset (px). */
+    offset: number;
+    /** Still smoothing toward a moving target next frame? */
+    following: boolean;
+    /** Clamped target this frame — fed back next frame to measure target velocity
+     *  (so the catch-up can land on a moving target, not trail it). */
+    prevTarget: number;
+}
+
+const clamp = (lo: number, hi: number, v: number): number => Math.min(hi, Math.max(lo, v));
+const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
+
+/**
+ * Advance the continuous-mode scroll one frame.
+ *
+ * @param offset      current offset (px)
+ * @param target      live target offset for the recited position (px)
+ * @param discont     this frame is a loopback/seek discontinuity (arms catch-up)
+ * @param following   were we mid-catch-up last frame?
+ * @param prevTarget  last frame's clamped target (for target-velocity landing)
+ * @param lastRight   max scrollable offset (px), for clamping
+ * @param reducedMotion skip the eased catch-up (jump straight to target)
+ */
+export function stepScroll(
+    offset: number,
+    target: number,
+    discont: boolean,
+    following: boolean,
+    prevTarget: number,
+    lastRight: number,
+    reducedMotion: boolean,
+): ScrollState {
+    const to = clamp(0, lastRight, target);
+    if (reducedMotion) return { offset: to, following: false, prevTarget: to };
+    const active = following || discont;
+    if (!active) return { offset: to, following: false, prevTarget: to };
+    // Velocity-aware landing: the recited target keeps moving during a replay, so
+    // land once the offset is within one frame's target motion of it (lockstep) —
+    // not just within a fixed px (which a moving target never reaches). On the arm
+    // frame (`!following`) there is no prior target yet, so velocity is 0.
+    const vel = following ? Math.abs(to - prevTarget) : 0;
+    if (Math.abs(to - offset) <= SNAP_EPS_PX + vel) {
+        return { offset: to, following: false, prevTarget: to };
+    }
+    return { offset: lerp(offset, to, GLIDE_FOLLOW), following: true, prevTarget: to };
+}

--- a/inspector/frontend/src/lib/recitation-animation/index.ts
+++ b/inspector/frontend/src/lib/recitation-animation/index.ts
@@ -37,6 +37,7 @@ export {
     type WordFrac,
     type WordWeighting,
 } from './filmstrip-model';
+export { stepScroll, type ScrollState } from './filmstrip-scroll';
 export type {
     AnimUnit,
     AyahBoundary,


### PR DESCRIPTION
## Why

PR #143 made the ayah filmstrip recitation-driven instead of clock-driven, but it regressed synchronisation in two ways the user reported:

1. **Desync** — during playback the filmstrip cell/scroll, the bottom `PlayerProgress`, and the true audio all drifted apart with "no consistency, all diverging."
2. **"Loop verse back" stuck** — looping a verse left playback "stuck on the current verse, paused forever as if it were silence."

## Root cause

#143 replaced live scroll tracking with a stale `glideTo` snapshot. In the continuous (`hybrid`/`tuner`) driver, while a glide tween was in flight the driver stopped writing the scroll offset entirely (`if (tween) return`) and glided toward a target captured **at jump time** — up to 1.5s old. On loopback-heavy reciters those glides chain, so the strip perpetually lagged and re-corrected against the live audio, and a loopback looked frozen ("paused like silence") for the duration of the glide.

A first pass replaced that freeze with a per-frame `stepScroll`, but it still eased toward the recited target with **fixed-fraction** smoothing. Because the target keeps moving forward during a replay, fixed-fraction easing toward a moving target converges to a **constant lag**, never zero — so the 1px landing test never fired and the scroll stayed ~14px behind for the whole looped-back stretch, only snapping back once linear forward play resumed. This matched the user's follow-up: "only gets fixed when the reciter continues linear after reaching back to the same place."

## What changed

- New pure stepper `filmstrip-scroll.ts::stepScroll`: instant in forward play; on a loopback/seek it arms a **velocity-aware** catch-up that chases the still-moving target and lands in **lockstep (zero lag)** rather than against a frozen point, then resumes instant tracking.
- `AyahFilmstrip.svelte` continuous driver now drives scroll via `stepScroll` (threading `followTarget`); the one-shot `glideTo` JS tween is kept only for discrete fixed-point moves (snap-center, click, key, drag-release). Cell highlight + word-fill were already correct — this fixes the **scroll position** across the entire replay window.

## Tests / verification

- `npm run check` → 0 errors. `npm run test` → **573 passed** (26 in the recitation-animation subset). ESLint clean.
- New unit tests for `stepScroll` including a moving-target lockstep guard that **fails against the constant-lag implementation**, plus a component test sampling **every frame across the loopback replay window**.

## Reviewer notes

- FE-only; no audio bytes / proxy / AudioPort involvement.
- **Not browser-smoke-tested** — this worktree has no bucket mount, so verification was deterministic rAF/component tests + a per-frame trace of the real component. A live loopback-reciter smoke before merge is worth it.
- Out of scope (flagged, not fixed): a rare `findActiveAt` overlap-tiebreak edge for VBR-melisma shapes where two occurrence intervals overlap in time — unrelated to this loopback bug; the verse-repeat corpus resolves correctly.