### PR TITLE
fix(segs-be,global-fe): guide-audio Range seek + info-modal bold links

### DIFF
--- a/inspector/frontend/src/lib/components/info/OverviewContent.svelte
+++ b/inspector/frontend/src/lib/components/info/OverviewContent.svelte
@@ -129,7 +129,7 @@
     });
 </script>
 
-{#snippet inline(tokens: InlineToken[])}{#each tokens as t, i (i)}{#if t.href}<a href={t.href} target="_blank" rel="noopener noreferrer">{t.text}</a>{:else if t.bold}<strong>{t.text}</strong>{:else}{t.text}{/if}{/each}{/snippet}
+{#snippet inline(tokens: InlineToken[])}{#each tokens as t, i (i)}{#if t.href}<a href={t.href} target="_blank" rel="noopener noreferrer">{#if t.bold}<strong>{t.text}</strong>{:else}{t.text}{/if}</a>{:else if t.bold}<strong>{t.text}</strong>{:else}{t.text}{/if}{/each}{/snippet}
 
 {#if sections.length > 1}
     <nav class="info-index" aria-label="Jump to section" bind:this={navEl}>

--- a/inspector/frontend/src/lib/components/info/__tests__/info-doc.test.ts
+++ b/inspector/frontend/src/lib/components/info/__tests__/info-doc.test.ts
@@ -47,6 +47,13 @@ describe('parseInline', () => {
             { bold: false, text: ' or reach out.' },
         ]);
     });
+
+    it('parses a bold-wrapped link into a single bold href run', () => {
+        expect(parseInline('**[GitHub Releases](https://x.test/r)** — JSON files.')).toEqual([
+            { bold: true, text: 'GitHub Releases', href: 'https://x.test/r' },
+            { bold: false, text: ' — JSON files.' },
+        ]);
+    });
 });
 
 describe('parseInfoDoc', () => {

--- a/inspector/frontend/src/lib/components/info/info-doc.ts
+++ b/inspector/frontend/src/lib/components/info/info-doc.ts
@@ -34,11 +34,14 @@ export interface InfoDoc {
     blocks: InfoBlock[];
 }
 
-// Matches either `**bold**` (group 1) or `[text](href)` (groups 2 + 3).
-const INLINE_RE = /\*\*([^*]+)\*\*|\[([^\]]+)\]\(([^)]+)\)/g;
+// Bold link `**[text](href)**` (groups 1+2) must come BEFORE plain bold, else
+// `**...**` swallows the link markup as literal text. Then `**bold**` (group 3)
+// and plain `[text](href)` (groups 4+5).
+const INLINE_RE =
+    /\*\*\[([^\]]+)\]\(([^)]+)\)\*\*|\*\*([^*]+)\*\*|\[([^\]]+)\]\(([^)]+)\)/g;
 const BUCKETS = new Set<string>(PUBLIC_BUCKETS);
 
-/** Split a line into bold / link / plain runs. Always returns ≥1 token. */
+/** Split a line into bold / link / bold-link / plain runs. Always returns ≥1 token. */
 export function parseInline(text: string): InlineToken[] {
     const tokens: InlineToken[] = [];
     let last = 0;
@@ -46,9 +49,11 @@ export function parseInline(text: string): InlineToken[] {
         const idx = m.index ?? 0;
         if (idx > last) tokens.push({ bold: false, text: text.slice(last, idx) });
         if (m[1] !== undefined) {
-            tokens.push({ bold: true, text: m[1] });
+            tokens.push({ bold: true, text: m[1], href: m[2] });
+        } else if (m[3] !== undefined) {
+            tokens.push({ bold: true, text: m[3] });
         } else {
-            tokens.push({ bold: false, text: m[2] ?? '', href: m[3] ?? '' });
+            tokens.push({ bold: false, text: m[4] ?? '', href: m[5] ?? '' });
         }
         last = idx + m[0].length;
     }

--- a/inspector/routes/public/static.py
+++ b/inspector/routes/public/static.py
@@ -13,6 +13,7 @@ picks its own cache discipline:
 from __future__ import annotations
 
 import re
+from io import BytesIO
 from pathlib import Path
 
 import orjson
@@ -115,14 +116,18 @@ def guide_audio(name: str) -> Response:
     local = _GUIDE_AUDIO_DIST / name
     if local.is_file() and not _is_lfs_pointer(local):
         resp = send_file(str(local), mimetype="audio/mpeg", conditional=True)
-        resp.headers["Cache-Control"] = _GUIDE_AUDIO_CACHE_CONTROL
-        return resp
-    from services.storage.hf_bucket import get_backend
+    else:
+        from services.storage.hf_bucket import get_backend
 
-    try:
-        body = get_backend().read_bytes(f"{_GUIDE_AUDIO_BUCKET_DIR}/{name}")
-    except Exception:
-        abort(404)
-    resp = Response(body, mimetype="audio/mpeg")
+        try:
+            body = get_backend().read_bytes(f"{_GUIDE_AUDIO_BUCKET_DIR}/{name}")
+        except Exception:
+            abort(404)
+        # send_file over BytesIO (not a bare Response) so Werkzeug honours Range:
+        # clip playback seeks into the file, so the larger clips need 206s.
+        resp = send_file(
+            BytesIO(body), mimetype="audio/mpeg", conditional=True, etag=f"guide-{name}-{len(body)}"
+        )
     resp.headers["Cache-Control"] = _GUIDE_AUDIO_CACHE_CONTROL
+    resp.headers["Accept-Ranges"] = "bytes"
     return resp


### PR DESCRIPTION
Two follow-ups that missed #154 (it squash-merged before these landed on the branch).

## 1. guide-audio route honours Range (regression from #154)
#154's bucket-fallback branch returned a bare `Response` (no HTTP Range). Clip playback (AudioRange) **seeks** into the file, needing `206`s — so the larger **merge/split/reps** guide clips (>100 KB → bucket-served on the Space) played the wrong range with a mis-placed waveform cursor; small (<100 KB, local `send_file`) clips were fine. Now serves via `send_file(BytesIO, conditional=True)` + `Accept-Ranges: bytes` (mirrors the audio-proxy in-memory path); both branches advertise ranges.

## 2. info-modal bold-wrapped links render
`**[GitHub Releases](url)**` parsed as plain bold — the `**…**` regex swallowed the link markup as literal text, so the Data-access links rendered raw. Added a bold-link regex alternative (before plain-bold) → `{bold, text, href}`, rendered as a bold anchor. +parser test.

Verified: info-doc tests 9/9, `npm run check` 0 errors.