### PR TITLE
fix(global-be,segs-fe): release one-claim hold once a claim is marked ready

### DIFF
--- a/.claude/rules/commit.md
+++ b/.claude/rules/commit.md
@@ -20,7 +20,7 @@ prefix(scope): imperative description
 - Lowercase prefix
 - Imperative mood after prefix e.g. `add`, `fix`
 - Subject ≤72 chars. Name the unit then the change: `prefix(scope): <target> — <what>` (e.g. `<target>` = the script/file/function). Keep detail — parentheticals, `+`-lists, schema/field names — in the body, not crammed into the subject.
-- Short comprehensive bullets — cover what changed, and why if relevant, not just listing files
+- Short comprehensive bullets — cover what changed, and briefly why
 - Do not commit as Claude or say co-authored by Claude or attribution. Commit as user 
 - Do not be verbose. 1-2 bullets default. 3 max for complex commits
 
@@ -32,12 +32,17 @@ prefix(scope): imperative description
 
 Format as `<prefix>(<area(s)>-<concern(s)>)`
 
-areas: `board`, `board-admin`, `segs`, `ts` (`global` for whole app) | `scripts`
+areas: `board`, `admin` (admin dashboard), `segs`, `ts`, `global` for whole app, `jobs`, `releases`
 
 concerns: `ui`, `fe`, `be`, `db`, `audio`, etc. or blank
 
 - Use these area names, not component names — whole-app FE is `global-fe`.
-- Join multiple areas/concerns with commas: `fix(board-be,scripts): …`.
+- Join multiple areas/concerns with commas: `fix(board-be,ts-be,scripts)`
+- Not every area needs a concern necessarily
+
+## PRs
+
+PR titles follow the same rule, since we squash-merge.
 
 ## Gitignored 
 

--- a/docs/reference/auth-permissions.md
+++ b/docs/reference/auth-permissions.md
@@ -29,7 +29,7 @@ Flat shims re-export it: `from services import auth`, `from services import perm
 | login | `GET /api/auth/login?return=<path>` | 503 if `is_oauth_configured()` false; stores `_safe_return_path` in flask session; `authorize_redirect(_callback_url())` |
 | callback | `GET /api/auth/callback` | exchanges code; reads `userinfo.sub` → `hf_user_id`, `preferred_username`/`name` → `login`; `encode_session(login, hf_user_id)`; sets cookie; 302 to safe return path |
 | logout | `POST /api/auth/logout` | clears cookie (`max_age=0`). Claims survive |
-| me | `GET /api/me` | `{login, hf_user_id, role, active_claim, active_claims, dev_mode}`; uniform null-filled shape when anonymous |
+| me | `GET /api/me` | `{login, hf_user_id, role, active_claim, active_claims, dev_mode}`; uniform null-filled shape when anonymous. `active_claim` = the **blocking** claim (open, not-marked-ready; via `repo_claims.open_claim_for_user`) — the field every FE one-claim gate keys off; marking ready releases the one-at-a-time hold so it drops to null. `active_claims` = the full under-review set assigned to the user (a marked-ready reciter stays in it; drives the picker's "mine" highlight) |
 | current user | `auth.py::current_user() -> User \| None` | reads cookie → `decode_session` → `resolve_role`; returns `User(hf_user_id, login, role)` frozen dataclass with live `role` |
 
 `is_oauth_configured()` = `OAUTH_CLIENT_ID` set AND `get_session_secret()` doesn't raise `MissingSecret`.

--- a/inspector/frontend/src/lib/components/__tests__/ClaimButton.test.ts
+++ b/inspector/frontend/src/lib/components/__tests__/ClaimButton.test.ts
@@ -108,6 +108,28 @@ describe('ClaimButton', () => {
         expect(btn!.classList.contains('lg')).toBe(false);
     });
 
+    it('renders the Claim button once the held claim is marked ready (active_claim null, active_claims non-empty)', () => {
+        // Marking ready clears the blocking `active_claim` but leaves the
+        // reciter in `active_claims` — the contributor is now free to claim a
+        // different one, so the button must surface for the new slug.
+        currentUser.set({
+            login: 'me',
+            hf_user_id: 'u-1',
+            role: 'contributor',
+            active_claim: null,
+            active_claims: ['marked-ready-slug'],
+            dev_mode: false,
+            capabilities: [],
+            guides_read: [],
+        });
+
+        const { container } = render(ClaimButton, {
+            props: { slug: 'different-reciter', task: makeTask(true), onClaimed: null },
+        });
+
+        expect(container.querySelector('button')).not.toBeNull();
+    });
+
     it('is labelled "Claim review" and opens the confirm modal on click (no immediate claim)', () => {
         closeClaimConfirm();
         currentUser.set({

--- a/inspector/frontend/src/lib/stores/current-user.ts
+++ b/inspector/frontend/src/lib/stores/current-user.ts
@@ -2,7 +2,7 @@
  * Current-user identity store.
  *
  * Loaded on app boot from `/api/me`. Replaced after sign-in/sign-out and
- * after any state-mutating claim action that touches `active_claim`.
+ * after any state-mutating claim action that touches the blocking claim.
  *
  * Shape is stable for anonymous (all fields null) so consumers can read
  * the same schema regardless of auth state.
@@ -18,9 +18,15 @@ export interface CurrentUser {
     login: string | null;
     hf_user_id: string | null;
     role: Role;
-    /** The primary active claim slug (first of `active_claims`, or null). */
+    /**
+     * The *blocking* claim slug — the open, not-yet-marked-ready claim that
+     * prevents the user from claiming another (null once they mark it ready or
+     * hold none). Owners are exempt from the one-at-a-time rule. This is the
+     * field every one-claim gate keys off.
+     */
     active_claim: string | null;
-    /** All slugs currently under_review and assigned to this user. Owners may hold multiple. */
+    /** All slugs currently under_review and assigned to this user (a marked-ready
+     *  reciter stays here). Owners may hold multiple. */
     active_claims: string[];
     /**
      * True when the backend is running with the dev-mode auth bypass

--- a/inspector/frontend/src/tabs/segments/components/footer/SegmentsFooter.svelte
+++ b/inspector/frontend/src/tabs/segments/components/footer/SegmentsFooter.svelte
@@ -484,7 +484,8 @@
                              or send back (force-release). The pill is a passive
                              status indicator, not a button. -->
                         <span class="status-pill marked-ready" title="Awaiting admin review">
-                            Marked ready · awaiting admin
+                            <span class="pill-main">Marked ready · awaiting admin</span>
+                            <span class="pill-hint">You can claim a different reciter</span>
                         </span>
                     {:else}
                         <ClaimButton slug={$selectedReciter || ''} task={reciterTask} {onClaimed} />
@@ -856,15 +857,21 @@
        once the reviewer has submitted. Passive: no hover, no cursor. */
     .status-pill.marked-ready {
         display: inline-flex;
-        align-items: center;
-        padding: 5px 12px;
-        font: 500 var(--fs-meta)/1 var(--font-sans);
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1px;
+        padding: 4px 12px;
+        font: 500 var(--fs-meta)/1.25 var(--font-sans);
         color: var(--state-warn-fg);
         background: oklch(from var(--state-warn-fg) l c h / 0.10);
         border: 1px solid oklch(from var(--state-warn-fg) l c h / 0.40);
         border-radius: var(--r-pill);
         letter-spacing: 0.01em;
         white-space: nowrap;
+    }
+    .status-pill.marked-ready .pill-hint {
+        font-weight: 400;
+        opacity: 0.75;
     }
     .save-group {
         display: inline-flex;

--- a/inspector/routes/auth/auth.py
+++ b/inspector/routes/auth/auth.py
@@ -22,7 +22,7 @@ from services import auth as auth_service
 from services import state as state_service
 from services.admin import visitors as visitor_service
 from services.auth import capabilities as cap_service
-from services.db import repo_access, repo_guides
+from services.db import repo_access, repo_claims, repo_guides
 from services.db import sync as _sync
 
 logger = logging.getLogger(__name__)
@@ -218,7 +218,14 @@ def auth_logout():
 @auth_bp.route("/me")
 def auth_me():
     """Identity + active_claim(s). Anonymous gets a null-filled shape so the
-    SPA reads a uniform schema regardless of auth state."""
+    SPA reads a uniform schema regardless of auth state.
+
+    ``active_claim`` is the *blocking* claim — the open, not-yet-marked-ready
+    claim that prevents the user from claiming another (null once they mark it
+    ready or hold none). ``active_claims`` is the full set of under-review slugs
+    assigned to them (a marked-ready reciter stays in this list). Marking ready
+    therefore releases the one-at-a-time hold, mirroring the backend policy in
+    ``repo_claims.open_claim_for_user``."""
     user = auth_service.current_user()
     dev_mode = auth_service.is_dev_mode()
     if user is None:
@@ -251,13 +258,18 @@ def auth_me():
         for r in state_service.all_rows()
         if r.state == ReciterState.UNDER_REVIEW and r.assignee_hf_id == user.hf_user_id
     ]
+    # The blocking claim excludes marked-ready rows (admin-side until publish /
+    # send-back), so a contributor is free to claim something new once they
+    # submit. ``active_claims`` above keeps the full under-review set for the
+    # picker's "mine" highlight.
+    blocking_claim = repo_claims.open_claim_for_user(user.hf_user_id)
     role_val = user.role.value if hasattr(user.role, "value") else user.role
     return jsonify(
         {
             "login": user.login,
             "hf_user_id": user.hf_user_id,
             "role": role_val,
-            "active_claim": active_claims[0] if active_claims else None,
+            "active_claim": blocking_claim,
             "active_claims": active_claims,
             "dev_mode": dev_mode,
             # Resolved capability ids the caller currently holds — recomputed fresh

--- a/inspector/tests/routes/test_route_auth.py
+++ b/inspector/tests/routes/test_route_auth.py
@@ -17,7 +17,11 @@ import json
 
 
 def _seed_state_row(
-    slug: str, *, assignee_hf_id: str | None = None, state: str = "awaiting_review"
+    slug: str,
+    *,
+    assignee_hf_id: str | None = None,
+    state: str = "awaiting_review",
+    marked_ready: bool = False,
 ):
     """Seed a single state row for ``slug`` into the SQLite substrate."""
     from tests.conftest import _seed_state
@@ -28,6 +32,7 @@ def _seed_state_row(
         assignee_hf_id=assignee_hf_id,
         assignee_login="someone" if assignee_hf_id else "test_user",
         visibility="public",
+        marked_ready=marked_ready,
     )
 
 
@@ -71,6 +76,21 @@ def test_me_active_claim_reflects_held_under_review(signed_in_client):
     resp = client.get("/api/me")
     assert resp.status_code == 200
     assert json.loads(resp.data)["active_claim"] == "test_slug"
+
+
+def test_me_marked_ready_claim_does_not_block(signed_in_client):
+    """A marked-ready claim is admin-side: it drops out of ``active_claim``
+    (so the one-at-a-time hold is released and the user can claim another)
+    but stays in ``active_claims`` (still assigned to them)."""
+    _seed_state_row(
+        "ready_slug", assignee_hf_id="u-3", state="under_review", marked_ready=True
+    )
+    client, user = signed_in_client(hf_user_id="u-3", login="carol", role="contributor")
+    resp = client.get("/api/me")
+    assert resp.status_code == 200
+    body = json.loads(resp.data)
+    assert body["active_claim"] is None
+    assert body["active_claims"] == ["ready_slug"]
 
 
 def test_me_role_reflects_live_access_revoke(signed_in_client):

--- a/inspector/tests/routes/test_route_auth.py
+++ b/inspector/tests/routes/test_route_auth.py
@@ -82,9 +82,7 @@ def test_me_marked_ready_claim_does_not_block(signed_in_client):
     """A marked-ready claim is admin-side: it drops out of ``active_claim``
     (so the one-at-a-time hold is released and the user can claim another)
     but stays in ``active_claims`` (still assigned to them)."""
-    _seed_state_row(
-        "ready_slug", assignee_hf_id="u-3", state="under_review", marked_ready=True
-    )
+    _seed_state_row("ready_slug", assignee_hf_id="u-3", state="under_review", marked_ready=True)
     client, user = signed_in_client(hf_user_id="u-3", login="carol", role="contributor")
     resp = client.get("/api/me")
     assert resp.status_code == 200

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -25,4 +25,19 @@ export default {
         if (abs.length === 0) return [];
         return `node ${eslintBin} --config ${eslintConfig} --fix ${abs.join(' ')}`;
     },
+    // Python: ruff lint-autofix + format, mirroring the backend-checks CI job.
+    // The set of linted vs excluded paths is owned entirely by ruff.toml (its
+    // target dirs + extend-exclude) — NOT re-listed here. `--force-exclude`
+    // makes ruff apply those excludes to explicitly-passed files, so a new
+    // top-level package is covered automatically and an excluded tree
+    // (inspector/frontend, .local, the embedded repos) is skipped with no
+    // second list to drift. Invoked as `python -m ruff` since the console
+    // script isn't always on PATH.
+    '**/*.py': (filenames) => {
+        const files = filenames.join(' ');
+        return [
+            `python -m ruff check --fix --force-exclude ${files}`,
+            `python -m ruff format --force-exclude ${files}`,
+        ];
+    },
 };

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -5,6 +6,29 @@ const root = path.dirname(fileURLToPath(import.meta.url));
 const frontendRoot = path.join(root, 'inspector', 'frontend');
 const eslintBin = path.join(frontendRoot, 'node_modules', 'eslint', 'bin', 'eslint.js');
 const eslintConfig = path.join(frontendRoot, 'eslint.config.js');
+
+/**
+ * Resolve how to invoke ruff on this machine, probed once at config load.
+ * Interpreter names vary (`python` vs `python3` vs the Windows `py` launcher)
+ * and ruff may instead be on PATH as the bare console script (as in CI), so we
+ * try each and keep the first that actually runs. Returns the command prefix
+ * (e.g. `"python -m ruff"`) or null when ruff is unavailable.
+ */
+function resolveRuff() {
+    const candidates = [
+        ['python', '-m', 'ruff'],
+        ['python3', '-m', 'ruff'],
+        ['py', '-m', 'ruff'],
+        ['ruff'],
+    ];
+    for (const c of candidates) {
+        const res = spawnSync(c[0], [...c.slice(1), '--version'], { stdio: 'ignore' });
+        if (res.status === 0) return c.join(' ');
+    }
+    return null;
+}
+
+const ruffCmd = resolveRuff();
 
 /** @type {import('lint-staged').Configuration} */
 export default {
@@ -31,13 +55,19 @@ export default {
     // makes ruff apply those excludes to explicitly-passed files, so a new
     // top-level package is covered automatically and an excluded tree
     // (inspector/frontend, .local, the embedded repos) is skipped with no
-    // second list to drift. Invoked as `python -m ruff` since the console
-    // script isn't always on PATH.
+    // second list to drift.
     '**/*.py': (filenames) => {
+        if (!ruffCmd) {
+            console.warn(
+                '[lint-staged] ruff not found (tried python/python3/py -m ruff and bare ruff); ' +
+                    'skipping Python lint/format. Install ruff to enable the pre-commit check.',
+            );
+            return [];
+        }
         const files = filenames.join(' ');
         return [
-            `python -m ruff check --fix --force-exclude ${files}`,
-            `python -m ruff format --force-exclude ${files}`,
+            `${ruffCmd} check --fix --force-exclude ${files}`,
+            `${ruffCmd} format --force-exclude ${files}`,
         ];
     },
 };


### PR DESCRIPTION
## What

Lets a contributor claim a different reciter as soon as their current claim is **marked ready** (submitted for admin review), instead of being stuck on one until an admin publishes or sends it back.

## Why

A contributor can hold only one *active* claim at a time. Once they mark a reciter ready, the work is admin-side — they can do nothing more on it — yet the UI kept blocking new claims, forcing them to *unclaim* (abandoning their submission) just to start the next reciter.

The root cause was a **frontend/backend mismatch**, not a missing feature. The backend already permitted this: `repo_claims.open_claim_for_user()` (which backs both `POST /api/claim` enforcement and the `can_claim` predicate) excludes marked-ready rows. But `/api/me` computed `active_claim` as "first under-review reciter assigned to me" — and a marked-ready reciter is *still* under review — so it stayed in `active_claim`, and every FE one-claim gate keyed off that field kept blocking.

## Changes

- **`inspector/routes/auth/auth.py`** — `/api/me` now reports `active_claim` from `repo_claims.open_claim_for_user` (the *blocking*, not-marked-ready claim) instead of `active_claims[0]`. `active_claims` (plural) stays the full under-review set for the picker's "mine" highlight. This one change unblocks all three FE entry points at once (ClaimButton, ClaimConfirmModal, edit-popover `holds-other-claim`).
- **`SegmentsFooter.svelte`** — the marked-ready pill is now two lines: "Marked ready · awaiting admin" + a quieter "You can claim a different reciter" hint.
- **`current-user.ts`** — documents `active_claim` as the blocking claim vs `active_claims` as the full set.
- **`docs/reference/auth-permissions.md`** — clarifies the `/api/me` shape.

## Reviewer notes

- No FE gate logic changed — the consumers already read `$currentUser.active_claim`; only the value the backend sends is corrected.
- Owners are exempt from the one-at-a-time rule in every consumer, so the value returned for an owner is harmless.

## Tests

- Backend (`test_route_auth.py`): `/api/me` with a marked-ready claim returns `active_claim: null` but `active_claims: [slug]`.
- Frontend (`ClaimButton.test.ts`): the Claim button surfaces for a different slug in that state.
- Verified: backend `test_route_auth.py` + `test_route_claims.py` → 43 passed; full FE suite → 597 passed; `svelte-check` 0 errors.
- Not run: live full-stack click-through (Flask + bucket); covered by automated tests.