### PR TITLE
refactor(admin): route all inspector-admin prod writes through prod_safe_setup

### DIFF
--- a/.claude/skills/inspector-admin/SKILL.md
+++ b/.claude/skills/inspector-admin/SKILL.md
@@ -77,17 +77,28 @@ python .claude/skills/inspector-admin/scripts/admin_db.py exec "select slug, sta
 
 The DB sync goes through `durable_transaction` so the new bytes land on the bucket before the script returns. **But** a bare `setup()` write against prod is *not durable*: the deployed Space is a second, live writer whose `db_seq` advances on every commit (visitor/activity heartbeats), so it overtakes the sync CAS — which only refuses a *lower* seq — and **clobbers the out-of-band edit within a minute or two**. (Observed: a reconcile of 11 ledger rows reverted to 5 after the Space's next write.)
 
-The safe path is **single-writer**: pause the Space → pull fresh → mutate → resume. Wrap every prod mutation in `prod_safe_setup` (in `_bootstrap.py`):
+The safe path is **single-writer**: pause the Space → pull fresh → mutate → resume.
+
+**Every script routes through `bs.run` — you don't call `setup` directly.** `run` takes the handler and two intent flags and picks the safe path automatically:
 
 ```python
-from _bootstrap import prod_safe_setup, add_common_args
+from _bootstrap import run, add_common_args
 add_common_args(p); a = p.parse_args()
-with prod_safe_setup(a, need_actor=False) as ctx:   # prod: pauses Space, pulls fresh
-    with durable_transaction() as con:
-        con.execute(...)                            # any bucket-DB mutation
-# Space auto-resumes here (in finally) → boots + re-pulls the corrected DB.
+write = a.cmd in ("set", "reset")          # this subcommand's intent
+return bs.run(
+    a,
+    lambda ctx: DISPATCH[a.cmd](a, ctx),
+    need_actor=write,     # construct the Actor (audit) for writes
+    mutates=write,        # any prod side effect → enforces --yes-prod
+    safe_write=write,     # IN-PROCESS bucket-DB write → run inside prod_safe_setup
+)
 ```
 
-`prod_safe_setup` pauses BEFORE the pull (snapshot = the Space's final state), runs the mutation as the sole writer, and **always resumes in `finally`** (a failed edit never leaves prod paused). On `--dev` it's a plain `setup()` — dev has no live Space, single-writer already. The Space re-pulls on boot (app.py boot = pull+migrate), so the edit is durable with no manual restart. Bare `setup()` remains for read-only ops (`admin_db exec` without `--write`, previews).
+- **`safe_write=True`** (a `durable_transaction` / `transition` / repo write) → on prod the whole handler runs inside `prod_safe_setup`: pause Space → pull fresh → mutate → resume (auto, in `finally`). This is the clobber-proof path.
+- **`safe_write=False` but `mutates=True`** → a **job launch** (`cut`, `hf-publish launch`, `ts launch`). It touches no DB in-process, so it must NOT pause (pausing would also break `--monitor`'s webhook) — but it still needs `--yes-prod`.
+- **`mutates=False`** → read-only (no actor, no pause, no `--yes-prod`).
+- **`--dev`** / **`--dry-run`** → never pauses (dev has no live Space; dry-run does no write).
+
+`setup` now **refuses a direct prod `safe_write` outside a `prod_safe_setup` window** (`sys.exit(2)`), so a bare prod DB write can't regress past `run`. The Space re-pulls on boot (app.py = pull+migrate), so the edit is durable with no manual restart.
 
 It guards **both** competing writers: the live Space (eliminated by the pause) and a **second concurrent admin run** — a TTL'd bucket advisory lock (`db/.admin_lock.json`, 20 min) is held across the whole pause→edit→resume window, so a second admin **aborts** (`admin lock held by '<login>' …`) rather than overlapping and un-pausing the Space mid-edit. A crashed holder's lock self-expires.

--- a/.claude/skills/inspector-admin/scripts/_bootstrap.py
+++ b/.claude/skills/inspector-admin/scripts/_bootstrap.py
@@ -57,6 +57,12 @@ BUCKETS = {
 # Deployed prod Space that holds the SQLite writer (single-writer invariant).
 PROD_SPACE_ID = os.environ.get("INSPECTOR_SPACE_ID", "hetchyy/quranic-universal-audio")
 
+# Set True only while inside a ``prod_safe_setup`` window (Space paused). ``setup``
+# refuses a prod MUTATION when this is False, so a bare prod write can't slip
+# through the clobber-prone path — every prod mutation must go via ``run`` /
+# ``prod_safe_setup``.
+_SAFE_WINDOW = False
+
 
 def repo_root() -> Path:
     # .claude/skills/inspector-admin/scripts/<file>.py → up 4 = repo root
@@ -107,7 +113,8 @@ class BootstrapCtx:
 
 def setup(args: argparse.Namespace, *, need_db: bool = True,
           need_actor: bool = True,
-          mutates: bool | None = None) -> BootstrapCtx:
+          mutates: bool | None = None,
+          safe_write: bool = False) -> BootstrapCtx:
     _ensure_utf8_stdout()
 
     rr = repo_root()
@@ -133,6 +140,20 @@ def setup(args: argparse.Namespace, *, need_db: bool = True,
             and not getattr(args, "yes_prod", False)
             and not getattr(args, "dry_run", False)):
         print("refusing to write to prod bucket without --yes-prod",
+              file=sys.stderr)
+        sys.exit(2)
+    # Single-writer guard: an in-process bucket-DB write (``safe_write``) MUST
+    # run inside a prod_safe_setup window (Space paused) or the live Space
+    # clobbers the edit within minutes. ``run(..., safe_write=True)`` routes it
+    # through that window automatically; a direct prod DB write here is a bug.
+    # (Job launches set safe_write=False — they touch no DB in-process, so they
+    # need --yes-prod but NOT the pause; pausing would also break --monitor.)
+    if (bucket_kind == "prod" and safe_write
+            and not getattr(args, "dry_run", False)
+            and not _SAFE_WINDOW):
+        print("refusing a direct prod DB write outside prod_safe_setup — route it "
+              "through bs.run(..., safe_write=True) so the Space is paused "
+              "(single-writer). See the skill's prod_safe_setup section.",
               file=sys.stderr)
         sys.exit(2)
 
@@ -257,9 +278,16 @@ def prod_safe_setup(args: argparse.Namespace, **setup_kw) -> Iterator[BootstrapC
             with durable_transaction() as con:
                 con.execute(...)            # any bucket-DB mutation
     """
+    global _SAFE_WINDOW
     prod = getattr(args, "prod", False)
     if not prod:
-        yield setup(args, **setup_kw)
+        # dev has no live Space — single writer already; just mark the window so
+        # setup()'s guard treats the (harmless) dev mutation as sanctioned.
+        _SAFE_WINDOW = True
+        try:
+            yield setup(args, **setup_kw)
+        finally:
+            _SAFE_WINDOW = False
         return
 
     _load_env()  # HF_TOKEN for HfApi + pause/restart
@@ -288,6 +316,7 @@ def prod_safe_setup(args: argparse.Namespace, **setup_kw) -> Iterator[BootstrapC
             print(f"space not confirmed PAUSED (stage={stage}); resuming, refusing to edit", flush=True)
             restart_space(PROD_SPACE_ID)
             raise RuntimeError(f"could not pause {PROD_SPACE_ID} for a safe write")
+        _SAFE_WINDOW = True
         try:
             yield setup(args, **setup_kw)  # pull fresh under pause
         finally:
@@ -295,7 +324,35 @@ def prod_safe_setup(args: argparse.Namespace, **setup_kw) -> Iterator[BootstrapC
             restart_space(PROD_SPACE_ID)
             _wait_space_stage(api, "RUNNING", timeout_s=180)
     finally:
+        _SAFE_WINDOW = False
         _release_admin_lock(backend, nonce)
+
+
+def run(args, handler, *, need_actor: bool = True, mutates: bool = True,
+        safe_write: bool = False, need_db: bool = True):
+    """Set up + run ``handler(ctx)``, prod-safe by construction.
+
+    The single entrypoint for every admin command. Two independent signals:
+
+    * ``mutates`` — the op has a prod side effect (DB write OR job launch); drives
+      the ``--yes-prod`` gate + actor construction.
+    * ``safe_write`` — the op does an IN-PROCESS bucket-DB write; when prod (and
+      not ``--dry-run``) the WHOLE handler runs inside ``prod_safe_setup`` so the
+      Space is paused single-writer for the write. Job launches set
+      ``safe_write=False`` — they touch no DB in-process, so pausing is both
+      unnecessary and harmful (it would break ``--monitor``'s webhook).
+
+    ``handler`` takes the ``BootstrapCtx`` and returns the process exit code.
+    """
+    prod = getattr(args, "prod", False)
+    dry = getattr(args, "dry_run", False)
+    if safe_write and prod and not dry:
+        with prod_safe_setup(args, need_actor=need_actor, need_db=need_db,
+                             mutates=mutates, safe_write=True) as ctx:
+            return handler(ctx)
+    ctx = setup(args, need_actor=need_actor, need_db=need_db,
+                mutates=mutates, safe_write=safe_write)
+    return handler(ctx)
 
 
 def after_write_banner(args: argparse.Namespace) -> None:

--- a/.claude/skills/inspector-admin/scripts/admin_claim.py
+++ b/.claude/skills/inspector-admin/scripts/admin_claim.py
@@ -84,8 +84,12 @@ def main() -> int:
     pra.add_argument("--to", required=True); pra.add_argument("--reason")
     bs.add_common_args(pra)
     a = p.parse_args()
-    ctx = bs.setup(a, need_actor=a.cmd != "show")
-    return {"show": _show, "release": _release, "reassign": _reassign}[a.cmd](a, ctx)
+    write = a.cmd in ("release", "reassign")
+    return bs.run(
+        a,
+        lambda ctx: {"show": _show, "release": _release, "reassign": _reassign}[a.cmd](a, ctx),
+        need_actor=write, mutates=write, safe_write=write,
+    )
 
 
 if __name__ == "__main__":

--- a/.claude/skills/inspector-admin/scripts/admin_db.py
+++ b/.claude/skills/inspector-admin/scripts/admin_db.py
@@ -75,11 +75,15 @@ def main() -> int:
     pt = sub.add_parser("tables"); bs.add_common_args(pt, mutating=False)
 
     a = p.parse_args()
-    # Read-only exec needs DB but not actor; --write needs both. Pass mutates
-    # explicitly so the --yes-prod gate fires for --write but skips for SELECT.
+    # Read-only exec needs DB but not actor; --write needs both + the single-
+    # writer pause (safe_write). bs.run routes the prod write through
+    # prod_safe_setup; SELECT/tables just read.
     is_write = a.cmd == "exec" and getattr(a, "write", False)
-    ctx = bs.setup(a, need_actor=is_write, mutates=is_write)
-    return {"exec": _exec, "tables": _tables}[a.cmd](a, ctx)
+    return bs.run(
+        a,
+        lambda ctx: {"exec": _exec, "tables": _tables}[a.cmd](a, ctx),
+        need_actor=is_write, mutates=is_write, safe_write=is_write,
+    )
 
 
 if __name__ == "__main__":

--- a/.claude/skills/inspector-admin/scripts/admin_hf_publish.py
+++ b/.claude/skills/inspector-admin/scripts/admin_hf_publish.py
@@ -101,8 +101,14 @@ def main() -> int:
     bs.add_common_args(pm, mutating=False)
 
     a = p.parse_args()
-    ctx = bs.setup(a, need_db=False, need_actor=False)
-    return {"launch": _do_launch, "monitor": _do_monitor}[a.cmd](a, ctx)
+    # launch only queues an HF job (no in-process DB write; --monitor needs the
+    # Space up) → mutates for the --yes-prod gate, but safe_write=False (no pause).
+    mutates = a.cmd == "launch"
+    return bs.run(
+        a,
+        lambda ctx: {"launch": _do_launch, "monitor": _do_monitor}[a.cmd](a, ctx),
+        need_actor=False, mutates=mutates, safe_write=False, need_db=False,
+    )
 
 
 if __name__ == "__main__":

--- a/.claude/skills/inspector-admin/scripts/admin_perms.py
+++ b/.claude/skills/inspector-admin/scripts/admin_perms.py
@@ -80,8 +80,12 @@ def main() -> int:
     bs.add_common_args(pr)
 
     a = p.parse_args()
-    ctx = bs.setup(a, need_actor=a.cmd != "matrix")
-    return {"matrix": _matrix, "set": _set, "reset": _reset}[a.cmd](a, ctx)
+    write = a.cmd in ("set", "reset")
+    return bs.run(
+        a,
+        lambda ctx: {"matrix": _matrix, "set": _set, "reset": _reset}[a.cmd](a, ctx),
+        need_actor=write, mutates=write, safe_write=write,
+    )
 
 
 if __name__ == "__main__":

--- a/.claude/skills/inspector-admin/scripts/admin_publish.py
+++ b/.claude/skills/inspector-admin/scripts/admin_publish.py
@@ -25,28 +25,31 @@ def main() -> int:
     bs.add_common_args(p)
     a = p.parse_args()
 
-    ctx = bs.setup(a)
-    from services.admin import timestamps_jobs  # noqa: E402
-    from services.state import state as state_service  # noqa: E402
+    def _run(ctx) -> int:
+        from services.admin import timestamps_jobs  # noqa: E402
+        from services.state import state as state_service  # noqa: E402
 
-    row = state_service.get_row(a.slug)
-    if row is None:
-        print(f"unknown slug {a.slug}", file=sys.stderr)
-        return 4
-    print(f"BEFORE: state={row.state.value}  marked_ready={row.marked_ready}")
+        row = state_service.get_row(a.slug)
+        if row is None:
+            print(f"unknown slug {a.slug}", file=sys.stderr)
+            return 4
+        print(f"BEFORE: state={row.state.value}  marked_ready={row.marked_ready}")
 
-    if a.dry_run:
-        print(f"DRY RUN — would call complete_timestamps_job({a.slug!r}, "
-              f"{a.job_id!r})")
+        if a.dry_run:
+            print(f"DRY RUN — would call complete_timestamps_job({a.slug!r}, "
+                  f"{a.job_id!r})")
+            return 0
+
+        result = timestamps_jobs.complete_timestamps_job(a.slug, a.job_id)
+        print(f"result: {result}")
+
+        row = state_service.get_row(a.slug)
+        print(f"AFTER:  state={row.state.value}  marked_ready={row.marked_ready}")
+        bs.after_write_banner(a)
         return 0
 
-    result = timestamps_jobs.complete_timestamps_job(a.slug, a.job_id)
-    print(f"result: {result}")
-
-    row = state_service.get_row(a.slug)
-    print(f"AFTER:  state={row.state.value}  marked_ready={row.marked_ready}")
-    bs.after_write_banner(a)
-    return 0
+    # complete_timestamps_job always does an in-process bucket-DB write.
+    return bs.run(a, _run, need_actor=True, mutates=True, safe_write=True)
 
 
 if __name__ == "__main__":

--- a/.claude/skills/inspector-admin/scripts/admin_release.py
+++ b/.claude/skills/inspector-admin/scripts/admin_release.py
@@ -240,13 +240,21 @@ def main() -> int:
 
     a = p.parse_args()
     need_db = a.cmd in {"preview", "cut", "complete"}
-    ctx = bs.setup(a, need_db=need_db, need_actor=False)
-    return {
-        "preview": _do_preview,
-        "cut": _do_cut,
-        "complete": _do_complete,
-        "monitor": _do_monitor,
-    }[a.cmd](a, ctx)
+    # cut + complete mutate (--yes-prod). Only `complete` does an in-process DB
+    # write (records the gh_releases ledger) → safe_write; `cut` only launches
+    # the HF job (the ledger lands later via webhook / `complete`).
+    mutates = a.cmd in ("cut", "complete")
+    safe_write = a.cmd == "complete"
+    return bs.run(
+        a,
+        lambda ctx: {
+            "preview": _do_preview,
+            "cut": _do_cut,
+            "complete": _do_complete,
+            "monitor": _do_monitor,
+        }[a.cmd](a, ctx),
+        need_actor=False, mutates=mutates, safe_write=safe_write, need_db=need_db,
+    )
 
 
 if __name__ == "__main__":

--- a/.claude/skills/inspector-admin/scripts/admin_requests.py
+++ b/.claude/skills/inspector-admin/scripts/admin_requests.py
@@ -100,10 +100,13 @@ def main() -> int:
     bs.add_common_args(pp, mutating=False)
 
     a = p.parse_args()
-    is_read_only = a.cmd in ("list", "show", "probe")
-    ctx = bs.setup(a, need_actor=not is_read_only)
-    return {"list": _list, "show": _show, "resolve": _resolve,
-            "accept": _accept, "probe": _probe}[a.cmd](a, ctx)
+    write = a.cmd in ("resolve", "accept")
+    return bs.run(
+        a,
+        lambda ctx: {"list": _list, "show": _show, "resolve": _resolve,
+                     "accept": _accept, "probe": _probe}[a.cmd](a, ctx),
+        need_actor=write, mutates=write, safe_write=write,
+    )
 
 
 if __name__ == "__main__":

--- a/.claude/skills/inspector-admin/scripts/admin_state.py
+++ b/.claude/skills/inspector-admin/scripts/admin_state.py
@@ -32,26 +32,29 @@ def main() -> int:
     bs.add_common_args(p)
     a = p.parse_args()
 
-    ctx = bs.setup(a)
-    from services.state import state as state_service  # noqa: E402
+    def _run(ctx) -> int:
+        from services.state import state as state_service  # noqa: E402
 
-    row = state_service.get_row(a.slug)
-    if row is None:
-        print(f"unknown slug {a.slug}", file=sys.stderr)
-        return 4
-    print(f"BEFORE: state={row.state.value}  marked_ready={row.marked_ready}")
+        row = state_service.get_row(a.slug)
+        if row is None:
+            print(f"unknown slug {a.slug}", file=sys.stderr)
+            return 4
+        print(f"BEFORE: state={row.state.value}  marked_ready={row.marked_ready}")
 
-    payload = json.loads(a.payload) if a.payload else None
-    if a.dry_run:
-        print(f"DRY RUN — would call transition(slug={a.slug!r}, event={a.event!r}, "
-              f"reason={a.reason!r}, payload={payload!r})")
+        payload = json.loads(a.payload) if a.payload else None
+        if a.dry_run:
+            print(f"DRY RUN — would call transition(slug={a.slug!r}, event={a.event!r}, "
+                  f"reason={a.reason!r}, payload={payload!r})")
+            return 0
+
+        new_row = state_service.transition(
+            a.slug, a.event, actor=ctx.actor, payload=payload, reason=a.reason)
+        print(f"AFTER:  state={new_row.state.value}  marked_ready={new_row.marked_ready}")
+        bs.after_write_banner(a)
         return 0
 
-    new_row = state_service.transition(
-        a.slug, a.event, actor=ctx.actor, payload=payload, reason=a.reason)
-    print(f"AFTER:  state={new_row.state.value}  marked_ready={new_row.marked_ready}")
-    bs.after_write_banner(a)
-    return 0
+    # transition() always does an in-process bucket-DB write.
+    return bs.run(a, _run, need_actor=True, mutates=True, safe_write=True)
 
 
 if __name__ == "__main__":

--- a/.claude/skills/inspector-admin/scripts/admin_ts_job.py
+++ b/.claude/skills/inspector-admin/scripts/admin_ts_job.py
@@ -192,13 +192,19 @@ def main() -> int:
     bs.add_common_args(pm, mutating=False)
 
     a = p.parse_args()
-    # status/record/history/monitor are read-only — need_actor=False saves the
-    # env-vars-must-exist check + skips actor construction.
-    is_read_only = a.cmd in ("status", "record", "history", "monitor")
-    ctx = bs.setup(a, need_actor=not is_read_only)
-    return {"launch": _do_launch, "cancel": _do_cancel, "status": _do_status,
-            "record": _do_record, "history": _do_history,
-            "publish": _do_publish, "monitor": _do_monitor}[a.cmd](a, ctx)
+    # launch/cancel/publish mutate (need actor + --yes-prod); status/record/
+    # history/monitor are read-only. Only cancel + publish do an in-process
+    # bucket-DB write (cancel_job / complete_timestamps_job) → safe_write; launch
+    # only queues an HF job (no DB write, and --monitor needs the Space up).
+    mutates = a.cmd in ("launch", "cancel", "publish")
+    safe_write = a.cmd in ("cancel", "publish")
+    return bs.run(
+        a,
+        lambda ctx: {"launch": _do_launch, "cancel": _do_cancel, "status": _do_status,
+                     "record": _do_record, "history": _do_history,
+                     "publish": _do_publish, "monitor": _do_monitor}[a.cmd](a, ctx),
+        need_actor=mutates, mutates=mutates, safe_write=safe_write,
+    )
 
 
 if __name__ == "__main__":

--- a/.claude/skills/inspector-admin/scripts/admin_users.py
+++ b/.claude/skills/inspector-admin/scripts/admin_users.py
@@ -67,8 +67,12 @@ def main() -> int:
                      choices=("owner", "maintainer", "contributor"))
     bs.add_common_args(psr)
     a = p.parse_args()
-    ctx = bs.setup(a, need_actor=a.cmd == "set-role")
-    return {"list": _list, "show": _show, "set-role": _set_role}[a.cmd](a, ctx)
+    write = a.cmd == "set-role"
+    return bs.run(
+        a,
+        lambda ctx: {"list": _list, "show": _show, "set-role": _set_role}[a.cmd](a, ctx),
+        need_actor=write, mutates=write, safe_write=write,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

The skill's SKILL.md prescribes `prod_safe_setup` (pause Space → pull → mutate → resume) for every prod mutation, but **no script actually used it** — every `admin_*.py` wrote through a bare `bs.setup()`. A bare prod write is non-durable: the live Space advances `db_seq` and clobbers the out-of-band edit within minutes (the documented failure: 11 ledger rows reverted to 5). So the safety was documented but not enforced.

## What this does

- **`bs.run(args, handler, *, need_actor, mutates, safe_write)`** — one entrypoint every command routes through. A prod **`safe_write`** (in-process bucket-DB write) runs the whole handler inside `prod_safe_setup`; everything else (dev, read-only, `--dry-run`) uses plain `setup`.
- **Two distinct signals**, because they differ:
  - `mutates` → any prod side effect (DB write **or** job launch) → enforces `--yes-prod` + builds the Actor.
  - `safe_write` → **in-process DB write only** → triggers the Space pause. Job launches (`cut`, `hf-publish launch`, `ts launch`) set `safe_write=False`: they touch no DB in-process, and pausing would break `--monitor`'s webhook.
- **Guard:** `setup()` now `sys.exit(2)` on a direct prod `safe_write` outside a `prod_safe_setup` window — a bare prod DB write can't regress past `run`.
- **Converted** all mutating scripts: `admin_state / publish / ts_job / release / requests / hf_publish / db / users / perms / claim`. `admin_reciter` stays read-only.
- **SKILL.md** updated to document `bs.run` as the standard.

## Tests

Verified the guard + routing directly: prod DB-write→pause; prod launch→no pause; dev→no pause; dry-run→no pause; missing `--yes-prod`→blocked; direct prod DB-write outside window→exit 2. All scripts compile.

Answers the question from PR #156's session: prod-safety is now automatic per command, not a per-script ceremony, and impossible to forget (the guard).