### PR TITLE
fix(global-be): scope activity rail to in-app publish, drop dataset-release cards

### DIFF
--- a/.claude/rules/commit.md
+++ b/.claude/rules/commit.md
@@ -20,7 +20,7 @@ prefix(scope): imperative description
 - Lowercase prefix
 - Imperative mood after prefix e.g. `add`, `fix`
 - Subject ≤72 chars. Name the unit then the change: `prefix(scope): <target> — <what>` (e.g. `<target>` = the script/file/function). Keep detail — parentheticals, `+`-lists, schema/field names — in the body, not crammed into the subject.
-- Short comprehensive bullets — cover what changed, and why if relevant, not just listing files
+- Short comprehensive bullets — cover what changed, and briefly why
 - Do not commit as Claude or say co-authored by Claude or attribution. Commit as user 
 - Do not be verbose. 1-2 bullets default. 3 max for complex commits
 
@@ -32,12 +32,17 @@ prefix(scope): imperative description
 
 Format as `<prefix>(<area(s)>-<concern(s)>)`
 
-areas: `board`, `board-admin`, `segs`, `ts` (`global` for whole app) | `scripts`
+areas: `board`, `admin` (admin dashboard), `segs`, `ts`, `global` for whole app, `jobs`, `releases`
 
 concerns: `ui`, `fe`, `be`, `db`, `audio`, etc. or blank
 
 - Use these area names, not component names — whole-app FE is `global-fe`.
-- Join multiple areas/concerns with commas: `fix(board-be,scripts): …`.
+- Join multiple areas/concerns with commas: `fix(board-be,ts-be,scripts)`
+- Not every area needs a concern necessarily
+
+## PRs
+
+PR titles follow the same rule, since we squash-merge.
 
 ## Gitignored 
 

--- a/docs/reference/dataset-and-releases.md
+++ b/docs/reference/dataset-and-releases.md
@@ -352,5 +352,6 @@ if they diverge where they should match, it's a bug.
 ## Event classification
 
 Publish actions fire events into
-[activity_classification.py](../../inspector/services/activity/activity_classification.py): TS
-generation is admin-only infrastructure; `released` / dataset-publish events are public.
+[activity_classification.py](../../inspector/services/activity/activity_classification.py): the
+in-app publish milestone `reciter.published` (TS-gen completion → `released` state) is public on
+the rail; `released` / dataset-publish events (HF push + GH cut) are hidden operator infrastructure.

--- a/inspector/services/activity/activity_classification.py
+++ b/inspector/services/activity/activity_classification.py
@@ -38,11 +38,11 @@ PUBLIC_EVENTS: dict[str, str] = {
     "reciter.requested": "requested",
     "reciter.alignment_completed": "available_review",
     "reciter.claimed": "under_review",
-    # `released` is the single v2 public-facing release event. Fires for BOTH
-    # HF dataset pushes (per-recitation) and GH release cuts (global), with the
-    # payload's ``track`` discriminating. v1's `reciter.published` (TS-gen
-    # completion) is admin infrastructure now and lives in HIDDEN_EVENTS.
-    "released": "released",
+    # `reciter.published` is the public publish milestone — fired by the system
+    # on timestamps-job completion (the `under_review → released` transition),
+    # meaning the reciter is now in-app published. Dataset/GH publishes
+    # (`released`) are operator infrastructure and live in HIDDEN_EVENTS.
+    "reciter.published": "published",
 }
 
 
@@ -60,10 +60,11 @@ HIDDEN_EVENTS: frozenset[str] = frozenset(
         "reciter.marked_ready",
         "reciter.unmarked_ready",
         "reciter.merge_rejected",
-        # `reciter.published` was wrongly on the public rail in v1 — it fires on
-        # TS-gen completion, which is admin infrastructure (not a public-release
-        # milestone). The v2 public `released` event covers HF / GH publishes.
-        "reciter.published",
+        # Dataset/GH publishes — fired for HF dataset pushes (per-recitation)
+        # and GH release cuts (global), discriminated by the payload's ``track``.
+        # Operator infrastructure surfaced via the Releases tab, not the public
+        # rail; the in-app publish milestone is `reciter.published` (PUBLIC).
+        "released",
         # Audit-only: a TS regen on an already-released reciter (no transition).
         # Operator-facing via the Releases tab's stale-stamp, not the public rail.
         "reciter.ts_regenerated",

--- a/inspector/services/activity/public_activity.py
+++ b/inspector/services/activity/public_activity.py
@@ -51,7 +51,7 @@ _TEMPLATES: dict[str, str] = {
     "requested": "{name} has been requested",
     "available_review": "{name} is now available for review",
     "under_review": "{name} is now under review",
-    "released": "{name} is now released",
+    "published": "{name} is now published",
 }
 
 

--- a/inspector/tests/services/test_activity_classification.py
+++ b/inspector/tests/services/test_activity_classification.py
@@ -52,10 +52,10 @@ def _record(
         ("catalog.added", "added"),
         ("reciter.alignment_completed", "available_review"),
         ("reciter.claimed", "under_review"),
-        # `released` covers BOTH HF dataset push + GH release cut in v2.
-        # `reciter.published` (TS gen completion) is HIDDEN in v2 — it's admin
-        # infrastructure, not a public-release milestone.
-        ("released", "released"),
+        # `reciter.published` (TS-gen completion → state becomes `released`) is
+        # the public publish milestone. Dataset/GH publishes (`released`) are
+        # HIDDEN — operator infrastructure, surfaced via the Releases tab.
+        ("reciter.published", "published"),
     ],
 )
 def test_public_events_classified_with_kind(event, expected_kind):
@@ -84,8 +84,9 @@ def test_awaiting_alignment_state_transition_classified_public_requested():
         "reciter.marked_ready",
         "reciter.unmarked_ready",
         "reciter.merge_rejected",
-        # v2: TS-gen completion is admin infrastructure (was wrongly PUBLIC in v1).
-        "reciter.published",
+        # Dataset/GH publishes — operator infrastructure (Releases tab), not the
+        # public rail. The in-app publish milestone is `reciter.published`.
+        "released",
         "reciter.unpublished",
         "reciter.discarded",
         "reciter.undiscarded",

--- a/inspector/tests/services/test_public_activity.py
+++ b/inspector/tests/services/test_public_activity.py
@@ -65,9 +65,9 @@ def test_classifies_allowlisted_events(monkeypatch):
             _record("catalog.added"),
             _record("reciter.alignment_completed"),
             _record("reciter.claimed"),
-            # v2: the public release event is `released` (covers HF push + GH cut).
-            # `reciter.published` (TS-gen completion) is HIDDEN now — admin-only.
-            _record("released"),
+            # The public publish milestone is `reciter.published` (TS-gen
+            # completion). Dataset/GH publishes (`released`) are HIDDEN now.
+            _record("reciter.published"),
             _record("state.transition", to_state="awaiting_alignment"),
         ],
     )
@@ -78,7 +78,7 @@ def test_classifies_allowlisted_events(monkeypatch):
     assert kinds == [
         "added",
         "available_review",
-        "released",
+        "published",
         "requested",
         "under_review",
     ]
@@ -137,8 +137,8 @@ def test_skips_failed_audit_records(monkeypatch):
 def test_card_text_uses_display_name_not_slug(monkeypatch):
     from services.public_activity import all_public_cards
 
-    # v2: `released` is the public-facing publish event.
-    _install_audit(monkeypatch, [_record("released", slug="husary_qdc")])
+    # `reciter.published` is the public-facing publish event.
+    _install_audit(monkeypatch, [_record("reciter.published", slug="husary_qdc")])
     _install_catalog(monkeypatch, {"husary_qdc": "Mahmoud Khalil Al-Husary"})
 
     cards = all_public_cards()


### PR DESCRIPTION
## Problem

The Dashboard Recent Activity rail showed entries like:

> Ahmed Saud (Hafs An Asim) (Murattal) **undefined** — @system · 4 minutes ago

Two issues, one root cause:

1. **The `undefined` bug.** The classifier had been switched so the public rail event was `released` (fired for *both* HF dataset pushes and GH release cuts), emitting card `kind: "released"`. The **frontend was never updated** — `ActivityRail.svelte`'s `ACTION` map and the `PublicEventKind` type only know `"published"`, so `ACTION["released"]` was `undefined` and got interpolated into the line. (Tell-tale: there's a `.marker-published` CSS rule but no `.marker-released`.)
2. **Wrong semantics.** We want a rail notification when a reciter becomes **published in-app** (the system-fired `reciter.published` transition on timestamps-job completion) and **nothing for dataset/GH releases**.

## Fix

Backend-only swap in `activity_classification.py`:

- `reciter.published` → **public**, kind `"published"` (the in-app publish milestone).
- `released` → **hidden** (dataset/GH publishes are operator infrastructure, surfaced via the Releases tab).

No frontend code change needed — the FE already expected `"published"`, so the `undefined` disappears. Read-time projection over the `transitions` log, so **no migration**: existing `reciter.published` rows in the rolling 2-month window now surface; `released` cards drop off.

Also updated: `_TEMPLATES` in `public_activity.py`, the two affected test files, and the `dataset-and-releases.md` classification note.

## Verification

- `pytest tests/services/test_activity_classification.py tests/services/test_public_activity.py` → 45 passed (incl. anti-drift: every state handler classified).
- `pytest tests/routes/ -k 'activity or public'` → 22 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)