### PR TITLE
feat(jobs-audio,releases): excise interior no-match audio from HF dataset verse clips

### DIFF
--- a/.claude/rules/commit.md
+++ b/.claude/rules/commit.md
@@ -20,7 +20,7 @@ prefix(scope): imperative description
 - Lowercase prefix
 - Imperative mood after prefix e.g. `add`, `fix`
 - Subject ≤72 chars. Name the unit then the change: `prefix(scope): <target> — <what>` (e.g. `<target>` = the script/file/function). Keep detail — parentheticals, `+`-lists, schema/field names — in the body, not crammed into the subject.
-- Short comprehensive bullets — cover what changed, and why if relevant, not just listing files
+- Short comprehensive bullets — cover what changed, and briefly why
 - Do not commit as Claude or say co-authored by Claude or attribution. Commit as user 
 - Do not be verbose. 1-2 bullets default. 3 max for complex commits
 
@@ -32,12 +32,17 @@ prefix(scope): imperative description
 
 Format as `<prefix>(<area(s)>-<concern(s)>)`
 
-areas: `board`, `board-admin`, `segs`, `ts` (`global` for whole app) | `scripts`
+areas: `board`, `admin` (admin dashboard), `segs`, `ts`, `global` for whole app, `jobs`, `releases`
 
 concerns: `ui`, `fe`, `be`, `db`, `audio`, etc. or blank
 
 - Use these area names, not component names — whole-app FE is `global-fe`.
-- Join multiple areas/concerns with commas: `fix(board-be,scripts): …`.
+- Join multiple areas/concerns with commas: `fix(board-be,ts-be,scripts)`
+- Not every area needs a concern necessarily
+
+## PRs
+
+PR titles follow the same rule, since we squash-merge.
 
 ## Gitignored 
 

--- a/docs/reference/dataset-and-releases.md
+++ b/docs/reference/dataset-and-releases.md
@@ -300,7 +300,10 @@ badges are a separate, broader metric maintained by `update-badges.yml` CI and a
 Embedded bytes are stream-copied from the bucket Xing-injected chapter master — source codec /
 bitrate / sample-rate / channels preserved; slice frame-snapped (≤26 ms earlier than first word,
 word timestamps re-based). Consumers resample at load; filter by codec/SR/channels via the
-`mushafs` config columns. For full-chapter app playback, prefer the GitHub release assets.
+`mushafs` config columns. For full-chapter app playback, prefer the GitHub release assets. A verse
+with an **interior no-match gap** is the one exception to "single contiguous slice": its clip is the
+kept runs stitched gaplessly (the no-match audio excised) — see
+[Failed-alignment, no-match & deletes](#failed-alignment-no-match--deletes-at-publish).
 
 ## Dedup semantics — what projection loses / preserves
 
@@ -321,13 +324,37 @@ Among multiple completing occasions the **earliest** (first recited) wins; a **l
 (a restart at word 1 whose run re-covers the verse) and **trailing** post-completion segments are
 trimmed. Consumers wanting alternate takes read the raw bucket shards (every segment present).
 
-### Failed-alignment & deletes at publish
+### Failed-alignment, no-match & deletes at publish
 
-`failed_alignment` (recorded in `_meta.mfa_failures`) and `deleted` (filtered at intake) both
-collapse to "never reached the bucket shard" — the segment-array shard carries only aligned,
-accepted segments. Per-verse, `project_segment_shard` keeps the canonical occasion; if no occasion
-reaches full coverage `{1..N}` it falls back to the widest-coverage occasion, and a verse with no
-shippable coverage is dropped from both the dataset and the GH tier files (logged for transparency).
+Three reviewer/pipeline actions converge to "never reached the bucket shard" — the segment-array
+shard carries only aligned, accepted, **ref-bearing** segments:
+
+- **No-match** = the reviewer enters an empty `matched_ref`. `build_mfa_ref` returns `None`, so the
+  segment is skipped before MFA (it leaves **no** `_meta.mfa_failures` entry) — it stays in
+  `detailed.json` with its time window but contributes no ref/text/words.
+- **Failed alignment** = MFA ran and returned non-`ok` (the only thing recorded in
+  `_meta.mfa_failures`).
+- **Deleted** = removed from `detailed.json` entirely (editor delete / filtered at intake).
+
+Per-verse, `project_segment_shard` keeps the canonical occasion; if no occasion reaches full
+coverage `{1..N}` it falls back to the widest-coverage occasion. Two distinct outcomes:
+
+- **Whole verse gone** (its only segment, or all its segments, missing) → the verse has zero shard
+  segments → `project_segment_shard` never emits it → it is dropped from **both** the HF dataset
+  (`build_rows`: `if not tdata: continue`) and the GH tier files (`if not words: continue`).
+- **Interior gap** (a middle segment missing — kept words 1-3 + 8-10, gap at 4-7) → the verse still
+  ships. Its word/letter/segment metadata and `text_uthmani` already exclude the gap words
+  (`coverage_gap` is reported but **non-fatal** — the verse is genuinely missing those words). The
+  clip window `[verse_start, verse_end]` spans the gap, so the **audio** would otherwise carry the
+  phantom no-match audio. The **HF dataset publish excises it**: `build_rows` computes `keep_runs`
+  (`[clip_start, clip_end]` minus the no-match segment spans, via `_subtract_spans`), and
+  `_slice_chapter` stitches the kept runs with `mp3_frames.slice_frames_multi` + `_rebase_row_multi`
+  (gapless re-base; logged per reciter). A contiguous verse (one run) takes the original
+  single-slice path unchanged. The **GH release** ships timestamps relative to source URLs (no
+  embedded audio), so it leaves the gap in place — its word timestamps simply skip it.
+  Leading/trailing no-match audio is already outside `[clip_start, clip_end]` (the window spans
+  first→last kept word), so only **interior** gaps stitch.
+
 Post-mark-ready, only in-verse segments exist (the TS job blocks compound cross-verse refs), so there
 are no cross-verse dedup cases.
 
@@ -348,6 +375,12 @@ same `project_segment_shard` canonical take over the same raw bucket segments. A
 byte-substring of the bucket chapter (after per-slice Xing if VBR); the dataset slice may start
 ≤26 ms before the first word (frame snap), with word timestamps re-based. **No intentional drift** —
 if they diverge where they should match, it's a bug.
+
+**One intentional exception:** for a verse with an interior no-match gap, the dataset clip excises
+the gap audio (stitched kept runs), while the in-app TS-tab segment-clip route is unchanged and
+still plays the contiguous `[verse_start, verse_end]` window including the gap. So for those (rare)
+verses the dataset audio is shorter than the TS-tab clip by the excised gap. Word timestamps still
+agree once re-based; only the audio bytes differ.
 
 ## Event classification
 

--- a/qua_jobs/publish_hf.py
+++ b/qua_jobs/publish_hf.py
@@ -42,7 +42,13 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from qua_shared.letter_vocab import to_external_char  # noqa: E402
-from qua_shared.mp3_frames import FrameIndex, build_frame_index, slice_frames  # noqa: E402
+from qua_shared.mp3_frames import (  # noqa: E402
+    FrameIndex,
+    MultiFrameSlice,
+    build_frame_index,
+    slice_frames,
+    slice_frames_multi,
+)
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s", datefmt="%H:%M:%S")
 log = logging.getLogger("publish_hf")
@@ -293,6 +299,29 @@ def _i(x):
     return int(round(x)) if isinstance(x, float) else int(x)
 
 
+def _subtract_spans(lo: int, hi: int, spans: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    """Return ``[lo, hi]`` minus ``spans`` as a list of kept runs (source-ms).
+
+    Used to excise interior no-match audio: ``spans`` are the no-match segments'
+    time windows inside a verse, ``[lo, hi]`` the verse clip window. With no
+    overlapping span the result is the single run ``[(lo, hi)]`` (the common,
+    no-gap case → identical to today's single contiguous slice). Overlapping /
+    out-of-window spans are clipped and merged.
+    """
+    clipped = sorted(
+        (max(lo, a), min(hi, b)) for a, b in spans if min(hi, b) > max(lo, a)
+    )
+    runs: list[tuple[int, int]] = []
+    cur = lo
+    for a, b in clipped:
+        if a > cur:
+            runs.append((cur, a))
+        cur = max(cur, b)
+    if cur < hi:
+        runs.append((cur, hi))
+    return runs
+
+
 def build_rows(
     timestamps: dict,
     detailed_by_ref: dict,
@@ -431,6 +460,24 @@ def build_rows(
                         }
                     )
 
+            # Kept audio runs = the verse clip window minus any INTERIOR
+            # no-match segment (empty matched_ref). A no-match segment stays in
+            # detailed.json with its time window but contributes no ref/text/
+            # words, so its audio would otherwise sit as a phantom gap inside the
+            # single contiguous clip. Subtracting its span splits the clip into
+            # runs the slicer stitches gaplessly. Leading/trailing no-match is
+            # already outside [clip_start, clip_end] (the window spans first→last
+            # kept word), so only interior gaps produce >1 run.
+            nomatch_spans: list[tuple[int, int]] = []
+            for seg in entry.get("segments", []) or []:
+                if seg.get("matched_ref", ""):
+                    continue  # has a ref → kept, not a no-match
+                a = max(clip_start, int(seg.get("time_start", 0)))
+                b = min(clip_end, int(seg.get("time_end", 0)))
+                if b > a:
+                    nomatch_spans.append((a, b))
+            keep_runs = _subtract_spans(int(clip_start), int(clip_end), nomatch_spans)
+
             # source_url + chapter info for slicer.
             chapter = int(surah_num)
             rows.append(
@@ -446,6 +493,7 @@ def build_rows(
                     "chapter": chapter,
                     "clip_start": clip_start,
                     "clip_end": clip_end,
+                    "keep_runs": keep_runs,
                 }
             )
     return rows
@@ -550,6 +598,47 @@ def _rebase_row(row: dict, actual_start_ms: int) -> None:
     for lt in row["letter_timestamps"]:
         lt["start_ms"] += delta
         lt["end_ms"] += delta
+
+
+def _rebase_row_multi(row: dict, runs: list) -> None:
+    """Re-base a stitched (gap-excised) clip's clip-relative times piecewise.
+
+    Each ``RunMap`` in ``runs`` maps a source-ms window onto the concatenated
+    clip timeline. A clip-relative time ``t`` (offset from the ORIGINAL
+    ``clip_start``) is re-anchored by finding the run its source time
+    ``t + clip_start`` falls in and mapping it to ``(t_src - run.actual_start_ms)
+    + run.cum_offset_ms`` — so the gap audio between runs is removed and the
+    surviving words/letters/segments play back-to-back. Sets ``duration_ms`` to
+    the stitched length and ``clip_start`` to the first run's snapped boundary
+    (the source offset of the clip's byte 0).
+    """
+    orig_cs = row["clip_start"]
+
+    def _map(t_rel: int) -> int:
+        t_src = t_rel + orig_cs
+        for r in runs:
+            if r.actual_start_ms <= t_src <= r.actual_end_ms:
+                return (t_src - r.actual_start_ms) + r.cum_offset_ms
+        # Defensive: a time outside every run (e.g. landed in an excised gap or
+        # past the end). Clamp to the nearest run boundary so the clip stays
+        # monotonic rather than crashing — kept words never hit this in practice.
+        if t_src <= runs[0].actual_start_ms:
+            return 0
+        for r in runs:
+            if t_src < r.actual_start_ms:
+                return r.cum_offset_ms
+        last = runs[-1]
+        return last.cum_offset_ms + (last.actual_end_ms - last.actual_start_ms)
+
+    total = sum(r.actual_end_ms - r.actual_start_ms for r in runs)
+    row["word_timestamps"] = [[w[0], _map(w[1]), _map(w[2])] for w in row["word_timestamps"]]
+    row["segments"] = [[s[0], s[1], _map(s[2]), _map(s[3])] for s in row["segments"]]
+    for lt in row["letter_timestamps"]:
+        lt["start_ms"] = _map(lt["start_ms"])
+        lt["end_ms"] = _map(lt["end_ms"])
+    row["clip_start"] = runs[0].actual_start_ms
+    row["duration_ms"] = total
+    row["clip_end"] = runs[0].actual_start_ms + total
 
 
 # ---------------------------------------------------------------------------
@@ -954,32 +1043,48 @@ def publish_slug(slug: str, job_id: str, *, sync_card: bool = True) -> dict:
     def _slice_chapter(chapter: int, chapter_rows: list[tuple[int, dict]]):
         """Read + index one chapter MP3, slice all its verse rows in-process.
 
-        Returns ``(produced, failures)`` where ``produced`` is a list of
-        ``(row_index, clip_bytes)`` and ``failures`` a list of ``"surah:ayah"``
-        labels. Rebases each produced row to its snapped frame boundary.
+        Returns ``(produced, failures, stitched)`` where ``produced`` is a list
+        of ``(row_index, clip_bytes)``, ``failures`` a list of ``"surah:ayah"``
+        labels, and ``stitched`` the ``"surah:ayah"`` labels whose clip excised
+        ≥1 interior no-match gap (>1 kept run). Contiguous verses (one run) take
+        the original single ``_frame_slice`` path unchanged.
         """
         src_bucket = _chapter_mp3_path(slug, chapter)
         if not src_bucket.exists():
-            return [], [f"{row['surah']}:{row['ayah']} (no audio)" for _, row in chapter_rows]
+            return [], [f"{row['surah']}:{row['ayah']} (no audio)" for _, row in chapter_rows], []
         try:
             data = src_bucket.read_bytes()
         except OSError as exc:
             log.warning("ch %d: read failed: %s", chapter, exc)
-            return [], [f"{row['surah']}:{row['ayah']} (read error)" for _, row in chapter_rows]
+            return [], [f"{row['surah']}:{row['ayah']} (read error)" for _, row in chapter_rows], []
         index = build_frame_index(data)
         if index.n_frames <= 0:
-            return [], [f"{row['surah']}:{row['ayah']} (no frames)" for _, row in chapter_rows]
+            return [], [f"{row['surah']}:{row['ayah']} (no frames)" for _, row in chapter_rows], []
         produced: list[tuple[int, bytes]] = []
         failures: list[str] = []
+        stitched: list[str] = []
         for i, row in chapter_rows:
-            cut = _frame_slice(data, index, row["clip_start"], row["clip_end"])
-            if cut is None:
-                failures.append(f"{row['surah']}:{row['ayah']}")
-                continue
-            clip_bytes, actual_start, _actual_end = cut
-            _rebase_row(row, actual_start)
-            produced.append((i, clip_bytes))
-        return produced, failures
+            keep_runs = row.get("keep_runs") or [(row["clip_start"], row["clip_end"])]
+            if len(keep_runs) <= 1:
+                # Common path: single contiguous run → byte-identical to before.
+                cut = _frame_slice(data, index, row["clip_start"], row["clip_end"])
+                if cut is None:
+                    failures.append(f"{row['surah']}:{row['ayah']}")
+                    continue
+                clip_bytes, actual_start, _actual_end = cut
+                _rebase_row(row, actual_start)
+                produced.append((i, clip_bytes))
+            else:
+                # Interior no-match gap(s): stitch the kept runs, drop the gap
+                # audio, rebase word/letter/segment times gaplessly.
+                ms: MultiFrameSlice | None = slice_frames_multi(data, index, keep_runs)
+                if ms is None:
+                    failures.append(f"{row['surah']}:{row['ayah']}")
+                    continue
+                _rebase_row_multi(row, ms.runs)
+                produced.append((i, ms.data))
+                stitched.append(f"{row['surah']}:{row['ayah']}")
+        return produced, failures, stitched
 
     workers = _slice_workers()
     progress_every = max(50, len(rows) // 20)
@@ -992,21 +1097,29 @@ def publish_slug(slug: str, job_id: str, *, sync_card: bool = True) -> dict:
     )
 
     done = 0
+    stitched_slices: list[str] = []
     with ThreadPoolExecutor(max_workers=workers) as pool:
         futures = {
             pool.submit(_slice_chapter, ch, rows_by_chapter[ch]): ch
             for ch in sorted(rows_by_chapter)
         }
         for fut in as_completed(futures):
-            produced, failures = fut.result()
+            produced, failures, stitched = fut.result()
             for idx, blob in produced:
                 audio_bytes[idx] = blob
             failed_slices.extend(failures)
+            stitched_slices.extend(stitched)
             done += len(produced) + len(failures)
             if done % progress_every < (len(produced) + len(failures)) or done == len(rows):
                 log.info("  sliced %d/%d (%d failed so far)", done, len(rows), len(failed_slices))
     sliced_count = sum(1 for b in audio_bytes if b is not None)
     log.info("audio: %d sliced, %d failed", sliced_count, len(failed_slices))
+    if stitched_slices:
+        log.info(
+            "audio: %d verse(s) had interior no-match gaps excised: %s",
+            len(stitched_slices),
+            sorted(stitched_slices)[:20],
+        )
     if failed_slices:
         log.warning("failed slices (first 20): %s", failed_slices[:20])
     if sliced_count == 0:

--- a/qua_jobs/publish_hf.py
+++ b/qua_jobs/publish_hf.py
@@ -308,9 +308,7 @@ def _subtract_spans(lo: int, hi: int, spans: list[tuple[int, int]]) -> list[tupl
     no-gap case → identical to today's single contiguous slice). Overlapping /
     out-of-window spans are clipped and merged.
     """
-    clipped = sorted(
-        (max(lo, a), min(hi, b)) for a, b in spans if min(hi, b) > max(lo, a)
-    )
+    clipped = sorted((max(lo, a), min(hi, b)) for a, b in spans if min(hi, b) > max(lo, a))
     runs: list[tuple[int, int]] = []
     cur = lo
     for a, b in clipped:

--- a/qua_shared/mp3_frames.py
+++ b/qua_shared/mp3_frames.py
@@ -254,3 +254,73 @@ def slice_frames(data: bytes, index: FrameIndex, start_ms: int, end_ms: int) -> 
         actual_start_ms=int(round(starts[i0])),
         actual_end_ms=int(round(starts[i1 + 1])),
     )
+
+
+@dataclass(frozen=True)
+class RunMap:
+    """One kept run inside a stitched (gap-excised) clip.
+
+    ``actual_start_ms`` / ``actual_end_ms`` are the snapped source-ms window the
+    run's frames cover (same semantics as ``FrameSlice``). ``cum_offset_ms`` is
+    the run's start position along the CONCATENATED clip's timeline (sum of all
+    prior runs' snapped durations) — so a source time ``t`` inside this run maps
+    to clip-relative ``(t - actual_start_ms) + cum_offset_ms``.
+    """
+
+    actual_start_ms: int
+    actual_end_ms: int
+    cum_offset_ms: int
+
+
+@dataclass(frozen=True)
+class MultiFrameSlice:
+    """A clip stitched from several non-adjacent frame ranges of one MP3.
+
+    ``data`` is the concatenated raw frames (headerless, same shape as
+    ``FrameSlice.data`` — a valid MP3 audio payload). ``runs`` carries one
+    ``RunMap`` per kept range, in clip order, for rebasing timestamps onto the
+    gap-excised timeline.
+    """
+
+    data: bytes
+    runs: list[RunMap]
+
+
+def slice_frames_multi(
+    data: bytes, index: FrameIndex, ranges: list[tuple[int, int]]
+) -> MultiFrameSlice | None:
+    """Slice several source-ms ranges and concatenate their frames into one clip.
+
+    Each ``(start_ms, end_ms)`` range is cut with ``slice_frames`` (independent
+    frame-boundary snap per range) and the raw frame bytes are concatenated in
+    order — excising whatever audio falls between the ranges (e.g. a no-match
+    gap). Ranges that slice to nothing are skipped; returns ``None`` if every
+    range drops or ``ranges`` is empty.
+
+    A single range yields the same bytes as ``slice_frames`` (the common,
+    no-gap case stays a no-op). Concatenating whole frames is byte-equivalent to
+    ffmpeg ``-c copy`` of each range appended; the only artifact is a brief
+    bit-reservoir discontinuity at each splice (acceptable — the same ~26 ms
+    frame snap already applies at every clip head).
+    """
+    if not ranges:
+        return None
+    parts: list[bytes] = []
+    runs: list[RunMap] = []
+    cum = 0
+    for start_ms, end_ms in ranges:
+        fs = slice_frames(data, index, start_ms, end_ms)
+        if fs is None:
+            continue
+        parts.append(fs.data)
+        runs.append(
+            RunMap(
+                actual_start_ms=fs.actual_start_ms,
+                actual_end_ms=fs.actual_end_ms,
+                cum_offset_ms=cum,
+            )
+        )
+        cum += fs.actual_end_ms - fs.actual_start_ms
+    if not parts:
+        return None
+    return MultiFrameSlice(data=b"".join(parts), runs=runs)

--- a/qua_shared/tests/test_mp3_frames.py
+++ b/qua_shared/tests/test_mp3_frames.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 import pytest
 
-from qua_shared.mp3_frames import build_frame_index, slice_frames
+from qua_shared.mp3_frames import build_frame_index, slice_frames, slice_frames_multi
 
 # ---------------------------------------------------------------------------
 # Synthetic MP3 byte-stream builders — no ffmpeg needed.
@@ -186,6 +186,63 @@ def test_overlapping_windows_each_copy_their_own_frames():
     overlap_frame = data[overlap_off : overlap_off + _frame_len(128)]
     assert overlap_frame in a.data
     assert overlap_frame in b.data
+
+
+# ---------------------------------------------------------------------------
+# slice_frames_multi — stitch non-adjacent ranges (interior no-match excision).
+# ---------------------------------------------------------------------------
+
+
+def test_multi_single_range_equals_slice_frames():
+    # One range must produce the exact same bytes as slice_frames (the common,
+    # no-gap path stays a byte-for-byte no-op).
+    data = _cbr_stream(100, with_id3=False)
+    idx = build_frame_index(data)
+    single = slice_frames(data, idx, 200, 800)
+    ms = slice_frames_multi(data, idx, [(200, 800)])
+    assert single is not None and ms is not None
+    assert ms.data == single.data
+    assert len(ms.runs) == 1
+    assert ms.runs[0].actual_start_ms == single.actual_start_ms
+    assert ms.runs[0].actual_end_ms == single.actual_end_ms
+    assert ms.runs[0].cum_offset_ms == 0
+
+
+def test_multi_excises_gap_and_concatenates_kept_runs():
+    data = _cbr_stream(100, with_id3=False)
+    idx = build_frame_index(data)
+    # Keep [0,300) and [600,900); excise the [300,600) middle.
+    run_a = slice_frames(data, idx, 0, 300)
+    run_c = slice_frames(data, idx, 600, 900)
+    ms = slice_frames_multi(data, idx, [(0, 300), (600, 900)])
+    assert run_a is not None and run_c is not None and ms is not None
+    # Concatenated bytes == run A bytes + run C bytes (gap dropped).
+    assert ms.data == run_a.data + run_c.data
+    # Two runs; second run's cum_offset == first run's snapped duration.
+    assert len(ms.runs) == 2
+    assert ms.runs[0].cum_offset_ms == 0
+    assert ms.runs[1].cum_offset_ms == run_a.actual_end_ms - run_a.actual_start_ms
+    # The gap is excised: the stitched clip is exactly the two kept runs (by
+    # construction) and strictly shorter than a single contiguous [0,900] slice.
+    # (Synthetic frames are byte-identical, so compare lengths, not contents.)
+    full = slice_frames(data, idx, 0, 900)
+    assert full is not None
+    assert len(ms.data) == len(run_a.data) + len(run_c.data)
+    assert len(ms.data) < len(full.data)
+
+
+def test_multi_drops_degenerate_ranges():
+    data = _cbr_stream(20, with_id3=False)
+    idx = build_frame_index(data)
+    # First range is degenerate (start>=end); only the second contributes.
+    ms = slice_frames_multi(data, idx, [(100, 100), (200, 400)])
+    only = slice_frames(data, idx, 200, 400)
+    assert ms is not None and only is not None
+    assert ms.data == only.data
+    assert len(ms.runs) == 1
+    # All-degenerate → None.
+    assert slice_frames_multi(data, idx, [(100, 100), (300, 200)]) is None
+    assert slice_frames_multi(data, idx, []) is None
 
 
 # ---------------------------------------------------------------------------

--- a/qua_shared/tests/test_publish_hf_build_rows.py
+++ b/qua_shared/tests/test_publish_hf_build_rows.py
@@ -8,7 +8,13 @@ comes from the audio manifest's chapter map).
 
 from __future__ import annotations
 
-from qua_jobs.publish_hf import _detailed_by_ref, _seg_word_range, build_rows
+from qua_jobs.publish_hf import (
+    _detailed_by_ref,
+    _rebase_row_multi,
+    _seg_word_range,
+    _subtract_spans,
+    build_rows,
+)
 
 _SURAH_INFO = {"1": {"verses": [{"verse": 1, "num_words": 4}, {"verse": 2, "num_words": 3}]}}
 
@@ -61,3 +67,99 @@ def test_build_rows_segments_and_source_url():
     # Word span 1->4 (basmala), NOT the collapsed [1, 1].
     assert row["segments"][0][0] == 1
     assert row["segments"][0][1] == 4
+
+
+# ---------------------------------------------------------------------------
+# Interior no-match audio excision: keep_runs + piecewise rebase + full drop.
+# ---------------------------------------------------------------------------
+
+
+def test_subtract_spans_no_gap_is_single_run():
+    assert _subtract_spans(0, 4000, []) == [(0, 4000)]
+    # A span outside the window is ignored.
+    assert _subtract_spans(0, 4000, [(5000, 6000)]) == [(0, 4000)]
+
+
+def test_subtract_spans_interior_and_overlapping():
+    assert _subtract_spans(0, 4000, [(2000, 3000)]) == [(0, 2000), (3000, 4000)]
+    # Overlapping / out-of-order spans are clipped + merged.
+    assert _subtract_spans(0, 4000, [(2500, 3000), (2000, 2600)]) == [(0, 2000), (3000, 4000)]
+    # Span clipped to the window edges.
+    assert _subtract_spans(0, 4000, [(-100, 500)]) == [(500, 4000)]
+
+
+def _ts(words, start, end):
+    return {"words": words, "letters": [], "verse_start_ms": start, "verse_end_ms": end}
+
+
+def test_build_rows_keep_runs_contiguous_single_run():
+    # No no-match segment → one run spanning the whole verse (today's behavior).
+    detailed = {
+        "entries": [
+            {"ref": "1:1", "segments": [{"time_start": 0, "time_end": 4000, "matched_ref": "1:1:1-1:1:4"}]}
+        ]
+    }
+    timestamps = {"1:1": _ts([[1, 0, 1000], [2, 1000, 2000], [3, 2000, 3000], [4, 3000, 4000]], 0, 4000)}
+    rows = build_rows(timestamps, _detailed_by_ref(detailed), _SURAH_INFO, {}, {"1": "u"})
+    assert rows[0]["keep_runs"] == [(0, 4000)]
+
+
+def test_build_rows_keep_runs_interior_no_match_splits():
+    # A no-match middle segment ([2000,3000], empty matched_ref) splits the clip
+    # into two kept runs so the slicer can excise the gap audio.
+    detailed = {
+        "entries": [
+            {
+                "ref": "1:1",
+                "segments": [
+                    {"time_start": 0, "time_end": 2000, "matched_ref": "1:1:1-1:1:2"},
+                    {"time_start": 2000, "time_end": 3000, "matched_ref": ""},  # no-match
+                    {"time_start": 3000, "time_end": 4000, "matched_ref": "1:1:3-1:1:4"},
+                ],
+            }
+        ]
+    }
+    timestamps = {"1:1": _ts([[1, 0, 1000], [2, 1000, 2000], [3, 3000, 3500], [4, 3500, 4000]], 0, 4000)}
+    rows = build_rows(timestamps, _detailed_by_ref(detailed), _SURAH_INFO, {}, {"1": "u"})
+    assert len(rows) == 1
+    assert rows[0]["keep_runs"] == [(0, 2000), (3000, 4000)]
+
+
+def test_build_rows_full_verse_no_match_drops_row():
+    # 1:2's only segment is no-match → the projection never emits 1:2, so it's
+    # absent from timestamps → no row built (point 2: full-verse drop).
+    detailed = {
+        "entries": [
+            {"ref": "1:1", "segments": [{"time_start": 0, "time_end": 4000, "matched_ref": "1:1:1-1:1:4"}]},
+            {"ref": "1:2", "segments": [{"time_start": 4000, "time_end": 6000, "matched_ref": ""}]},
+        ]
+    }
+    timestamps = {"1:1": _ts([[1, 0, 1000], [2, 1000, 2000], [3, 2000, 3000], [4, 3000, 4000]], 0, 4000)}
+    rows = build_rows(timestamps, _detailed_by_ref(detailed), _SURAH_INFO, {}, {"1": "u"})
+    assert [(r["surah"], r["ayah"]) for r in rows] == [(1, 1)]
+
+
+def test_rebase_row_multi_excises_gap_gaplessly():
+    from qua_shared.mp3_frames import RunMap
+
+    # Verse clip [0,4000] source; word 3 has a 1000 ms phantom gap before it
+    # (the excised no-match audio at [2000,3000]).
+    row = {
+        "clip_start": 0,
+        "clip_end": 4000,
+        "duration_ms": 4000,
+        "word_timestamps": [[1, 0, 1000], [2, 1000, 2000], [3, 3000, 3500], [4, 3500, 4000]],
+        "segments": [[1, 2, 0, 2000], [3, 4, 3000, 4000]],
+        "letter_timestamps": [{"word_idx": 3, "char": "x", "start_ms": 3000, "end_ms": 3100}],
+    }
+    # Runs: [0,2000) then [3000,4000) placed right after (cum_offset 2000).
+    runs = [RunMap(0, 2000, 0), RunMap(3000, 4000, 2000)]
+    _rebase_row_multi(row, runs)
+    assert row["duration_ms"] == 3000
+    assert row["clip_start"] == 0
+    assert row["clip_end"] == 3000
+    # Word 3 now starts exactly at word 2's end (2000) — the gap is gone.
+    assert row["word_timestamps"] == [[1, 0, 1000], [2, 1000, 2000], [3, 2000, 2500], [4, 2500, 3000]]
+    assert row["segments"] == [[1, 2, 0, 2000], [3, 4, 2000, 3000]]
+    assert row["letter_timestamps"][0]["start_ms"] == 2000
+    assert row["letter_timestamps"][0]["end_ms"] == 2100

--- a/qua_shared/tests/test_publish_hf_build_rows.py
+++ b/qua_shared/tests/test_publish_hf_build_rows.py
@@ -96,10 +96,15 @@ def test_build_rows_keep_runs_contiguous_single_run():
     # No no-match segment → one run spanning the whole verse (today's behavior).
     detailed = {
         "entries": [
-            {"ref": "1:1", "segments": [{"time_start": 0, "time_end": 4000, "matched_ref": "1:1:1-1:1:4"}]}
+            {
+                "ref": "1:1",
+                "segments": [{"time_start": 0, "time_end": 4000, "matched_ref": "1:1:1-1:1:4"}],
+            }
         ]
     }
-    timestamps = {"1:1": _ts([[1, 0, 1000], [2, 1000, 2000], [3, 2000, 3000], [4, 3000, 4000]], 0, 4000)}
+    timestamps = {
+        "1:1": _ts([[1, 0, 1000], [2, 1000, 2000], [3, 2000, 3000], [4, 3000, 4000]], 0, 4000)
+    }
     rows = build_rows(timestamps, _detailed_by_ref(detailed), _SURAH_INFO, {}, {"1": "u"})
     assert rows[0]["keep_runs"] == [(0, 4000)]
 
@@ -119,7 +124,9 @@ def test_build_rows_keep_runs_interior_no_match_splits():
             }
         ]
     }
-    timestamps = {"1:1": _ts([[1, 0, 1000], [2, 1000, 2000], [3, 3000, 3500], [4, 3500, 4000]], 0, 4000)}
+    timestamps = {
+        "1:1": _ts([[1, 0, 1000], [2, 1000, 2000], [3, 3000, 3500], [4, 3500, 4000]], 0, 4000)
+    }
     rows = build_rows(timestamps, _detailed_by_ref(detailed), _SURAH_INFO, {}, {"1": "u"})
     assert len(rows) == 1
     assert rows[0]["keep_runs"] == [(0, 2000), (3000, 4000)]
@@ -130,11 +137,16 @@ def test_build_rows_full_verse_no_match_drops_row():
     # absent from timestamps → no row built (point 2: full-verse drop).
     detailed = {
         "entries": [
-            {"ref": "1:1", "segments": [{"time_start": 0, "time_end": 4000, "matched_ref": "1:1:1-1:1:4"}]},
+            {
+                "ref": "1:1",
+                "segments": [{"time_start": 0, "time_end": 4000, "matched_ref": "1:1:1-1:1:4"}],
+            },
             {"ref": "1:2", "segments": [{"time_start": 4000, "time_end": 6000, "matched_ref": ""}]},
         ]
     }
-    timestamps = {"1:1": _ts([[1, 0, 1000], [2, 1000, 2000], [3, 2000, 3000], [4, 3000, 4000]], 0, 4000)}
+    timestamps = {
+        "1:1": _ts([[1, 0, 1000], [2, 1000, 2000], [3, 2000, 3000], [4, 3000, 4000]], 0, 4000)
+    }
     rows = build_rows(timestamps, _detailed_by_ref(detailed), _SURAH_INFO, {}, {"1": "u"})
     assert [(r["surah"], r["ayah"]) for r in rows] == [(1, 1)]
 
@@ -159,7 +171,12 @@ def test_rebase_row_multi_excises_gap_gaplessly():
     assert row["clip_start"] == 0
     assert row["clip_end"] == 3000
     # Word 3 now starts exactly at word 2's end (2000) — the gap is gone.
-    assert row["word_timestamps"] == [[1, 0, 1000], [2, 1000, 2000], [3, 2000, 2500], [4, 2500, 3000]]
+    assert row["word_timestamps"] == [
+        [1, 0, 1000],
+        [2, 1000, 2000],
+        [3, 2000, 2500],
+        [4, 2500, 3000],
+    ]
     assert row["segments"] == [[1, 2, 0, 2000], [3, 4, 2000, 3000]]
     assert row["letter_timestamps"][0]["start_ms"] == 2000
     assert row["letter_timestamps"][0]["end_ms"] == 2100


### PR DESCRIPTION
## Context

When a reviewer marks a segment **no match** (empty `matched_ref`), it's skipped before MFA and never reaches the bucket `timestamps/<ch>.json.gz` shard. Two cases mattered for the dataset/release adapters:

- **Whole verse no-match** (its only segment, or all its segments) → the verse has zero shard segments → already dropped from both the HF dataset and the GH tiers. ✅ already correct (now locked by a test).
- **Interior no-match gap** (kept words 1-3 + 8-10, gap at 4-7) → the verse still shipped, and although its word/letter/segment metadata and `text_uthmani` already excluded the gap words, the HF dataset **audio clip** was a single contiguous `[verse_start, verse_end]` slice that **still carried the phantom no-match audio**. That's the bug fixed here.

## What changed (HF dataset publish job only)

- `qua_shared/mp3_frames.py`: new `slice_frames_multi(data, index, ranges)` — slices several source-ms ranges and concatenates their raw frames (pure-Python frame-copy; a single range == `slice_frames`, so the common path is a no-op).
- `qua_jobs/publish_hf.py`:
  - `build_rows` computes `keep_runs` = `[clip_start, clip_end]` minus the no-match segment spans (new `_subtract_spans`).
  - `_slice_chapter`: 1 run → original single-slice path (byte-identical to before); >1 run → stitch via `slice_frames_multi` + new `_rebase_row_multi` (piecewise, gapless re-base). Stitched verses are logged per reciter.
- Only **interior** gaps stitch — leading/trailing no-match is already outside `[clip_start, clip_end]`.

### Scope decisions
- **GH release**: leaves the timestamps with the hole (ships timestamps into source URLs, no embedded audio to filter) — unchanged.
- **In-app TS-tab clip**: unchanged (intentional, documented dataset-vs-TS-tab divergence for these rare verses).
- **Stitch method**: pure-Python frame-copy — the publish job has no re-encoder (no ffmpeg/pydub/PyAV/soundfile; torchcodec is decode-only). Accepts the minor bit-reservoir splice click + ~26 ms per-range snap, consistent with the existing single-slice path. No new deps.
- A stitched verse is still missing the gap's Quran words (only the phantom audio is removed) → ships flagged by the existing **non-fatal** `coverage_gap`.

## Tests
- `slice_frames_multi`: single-range == `slice_frames`, gap excision, degenerate-range handling.
- publish job: `keep_runs` (contiguous / interior-split), `_subtract_spans`, piecewise gapless rebase, and **full-verse no-match → no row** (regression).
- `qua_shared` suite: 125 passed; ruff clean.

Docs: `docs/reference/dataset-and-releases.md` updated (failed-alignment/no-match section, audio-preserve note, TS-tab parity exception).