### PR TITLE
fix(ts-be): first word owns idgham merger duration in bridge timing

### DIFF
--- a/.claude/rules/commit.md
+++ b/.claude/rules/commit.md
@@ -20,7 +20,7 @@ prefix(scope): imperative description
 - Lowercase prefix
 - Imperative mood after prefix e.g. `add`, `fix`
 - Subject ≤72 chars. Name the unit then the change: `prefix(scope): <target> — <what>` (e.g. `<target>` = the script/file/function). Keep detail — parentheticals, `+`-lists, schema/field names — in the body, not crammed into the subject.
-- Short comprehensive bullets — cover what changed, and why if relevant, not just listing files
+- Short comprehensive bullets — cover what changed, and briefly why
 - Do not commit as Claude or say co-authored by Claude or attribution. Commit as user 
 - Do not be verbose. 1-2 bullets default. 3 max for complex commits
 
@@ -32,12 +32,17 @@ prefix(scope): imperative description
 
 Format as `<prefix>(<area(s)>-<concern(s)>)`
 
-areas: `board`, `board-admin`, `segs`, `ts` (`global` for whole app) | `scripts`
+areas: `board`, `admin` (admin dashboard), `segs`, `ts`, `global` for whole app, `jobs`, `releases`
 
 concerns: `ui`, `fe`, `be`, `db`, `audio`, etc. or blank
 
 - Use these area names, not component names — whole-app FE is `global-fe`.
-- Join multiple areas/concerns with commas: `fix(board-be,scripts): …`.
+- Join multiple areas/concerns with commas: `fix(board-be,ts-be,scripts)`
+- Not every area needs a concern necessarily
+
+## PRs
+
+PR titles follow the same rule, since we squash-merge.
 
 ## Gitignored 
 

--- a/qua_shared/tests/test_timestamps_bridges.py
+++ b/qua_shared/tests/test_timestamps_bridges.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import pytest
 
 from qua_shared.timestamps_bridges import (
+    _BRIDGE_SLOT,
     BRIDGE_RULES,
     _apply_to_words,
     _looks_like_merger,
@@ -48,6 +49,23 @@ def test_apply_reattributes_shafawi_kasra_to_next_word():
     # word start/end re-timed from the new phone slices.
     assert words[0][1] == 0 and words[0][2] == 3  # k.start .. m̃.end
     assert words[1][1] == 3 and words[1][2] == 5  # i.start .. ŋ.end
+
+
+def test_apply_first_word_owns_head_merger_duration():
+    # idgham ghunnah noon: مَن + يَ… , merger ñ/m̃ at the curr word's head.
+    # Flat: m i m̃ a n. The first word must hold through the merger so word
+    # highlighting stays on it during the ghunnah; the curr word starts after.
+    words = [_word(7, ["m", "i"]), _word(8, ["m̃", "a", "n"], t0=2)]
+    n = _apply_to_words(words, [(2, "idgham_ghunnah_noon")], [2, 3])
+    assert n == 1
+    # Phone attribution unchanged: the merger still lives on the curr word
+    # (lifted to the bridge tile by the FE) and carries its rule tag.
+    assert [p[0] for p in words[1][4]] == ["m̃", "a", "n"]
+    assert words[1][4][0][_BRIDGE_SLOT] == "idgham_ghunnah_noon"
+    # First word owns the merger duration: its envelope ends at the merger end.
+    assert words[0][1] == 0 and words[0][2] == 3  # m.start .. m̃.end
+    # Second word's envelope begins at its next phone, past the merger.
+    assert words[1][1] == 3 and words[1][2] == 5  # a.start .. n.end
 
 
 def test_apply_refuses_non_merger_index():

--- a/qua_shared/timestamps_bridges.py
+++ b/qua_shared/timestamps_bridges.py
@@ -173,7 +173,14 @@ def _apply_to_words(words: list, bridges: list[tuple[int, str]], counts: list[in
     ``counts`` is the phonemizer's per-word phone count; ``bridges`` is
     ``[(flat_index, rule), ...]``. Both index the segment's flat phone array (all
     phones across words in order). No-op + return 0 when the shapes don't line up
-    with the shard (guards against corrupting on unexpected phonemizer drift)."""
+    with the shard (guards against corrupting on unexpected phonemizer drift).
+
+    The merger's *duration* is always owned by the FIRST word of the boundary so
+    word highlighting / clips stay on it through the ghunnah: shafawi already
+    lands on the prev word's tail, and for the head-merger rules (idgham
+    ghunnah/bila-ghunnah …) the curr word's start is pushed past the merger and
+    the prev word's end is extended to the merger's end. Phone attribution is
+    untouched — the merger phone keeps its tag and renders in the bridge tile."""
     if len(counts) != len(words):
         return 0
     flat = [ph for wd in words for ph in wd[4] if ph[0]]
@@ -190,10 +197,26 @@ def _apply_to_words(words: list, bridges: list[tuple[int, str]], counts: list[in
             tagged += 1
 
     off = 0
+    head_to_word: dict[int, int] = {}
     for wi, c in enumerate(counts):
+        head_to_word[off] = wi
         words[wi][4] = flat[off : off + c]
         off += c
         _retime(words[wi])
+
+    for fidx, rule in bridges:
+        if rule in _MERGER_ON_PREV:
+            continue  # merger is the prev word's tail → first word already owns it
+        if not (0 <= fidx < len(flat)) or not _looks_like_merger(flat[fidx][0]):
+            continue
+        w = head_to_word.get(fidx)  # head-merger rules land the merger at a word head
+        if not w:  # None (not a head) or 0 (no prev word) → leave as-is
+            continue
+        cur = words[w][4]
+        if len(cur) < 2:
+            continue  # fully-dissolving word: nothing left to own its own span
+        words[w - 1][2] = flat[fidx][2]  # first word holds through the ghunnah
+        words[w][1] = cur[1][1]  # second word starts at its next phone
     return tagged
 
 


### PR DESCRIPTION
## What

On the Timestamps tab, while an idgham merge phoneme (the ghunnah / geminate "bridge") sounds, the **second** word was lighting up for the four `idgham_ghunnah_noon|tanween` / `idgham_bila_ghunnah_noon|tanween` rules. This makes the **first** word stay highlighted through the ghunnah, uniformly across every idgham rule.

## Why

Word highlighting is driven purely by the word `start`/`end` envelope (`updateHighlights` in `UnifiedDisplay.svelte`). The bridge step `_apply_to_words` re-slices phones to the phonemizer's canonical per-word counts and re-times each word from those phones — moving the merger onto the second word's head and pulling its `start` back, so the second word lit during the ghunnah. The merger *timestamp* is never moved; only which word's envelope contains it.

Per the phonemizer's ruling (`get_mapping()`), the merger is attributed to the second word for the four head-merger rules and to the first word's tail for `idgham_shafawi`. So "first word, uniformly" only changes the four head-merger rules; shafawi already satisfies it.

## Change

`qua_shared/timestamps_bridges.py::_apply_to_words` — after the canonical re-slice + `_retime`, a second pass gives the merger's **duration** to the first word for the head-merger rules: `word1.end` extends to the merger end, `word2.start` moves to its next phone. Guards skip shafawi (already prev-tail), word 0, non-head indices, and fully-dissolving words (`<2` phones). **Phone attribution + the bridge tile are unchanged** — the merger phone keeps its tag and still renders in the tile.

`word.start`/`end` is the single source for highlighting, the per-word clip/loop range, and the public dataset, so all stay consistent. **No FE change** (pure consumer of the envelopes).

## Scope

- **No backfill.** The fix runs in the bridge step inside every `generate_timestamps` job, so new TS runs pick it up automatically; existing published shards are byte-identical until a reciter is regenerated.

## Test

Added `test_apply_first_word_owns_head_merger_duration` and confirmed the existing shafawi test is unaffected. All 8 bridge tests pass:

```
cd inspector && python -m pytest ../qua_shared/tests/test_timestamps_bridges.py -v
# 8 passed
```