### PR TITLE
feat(jobs-be,releases): gate incomplete verses out of dataset + GH release

### DIFF
--- a/docs/reference/dataset-and-releases.md
+++ b/docs/reference/dataset-and-releases.md
@@ -99,7 +99,8 @@ The same predicate drives the Releases-tab buckets and the cut job's member disc
 
 1. Reads the bucket DB read-only → eligible reciters + the prior release's membership.
 2. Per reciter: reads every segment-array `timestamps/<ch>.json.gz` shard and projects the canonical
-   verse map (`_load_canonical_verses` → `project_segment_shard`, the earliest completing occasion)
+   verse map (`_load_canonical_verses` → `project_segment_shard`, the earliest completing occasion),
+   then drops incomplete verses via `select_complete_verses` (missing a reference word index)
    → builds the three
    tier files (verse/word/letter, top-down), `catalog.json`, a per-recitation `manifest.json`; packs
    a deterministic `<slug>.zip`; computes `content_hash = SHA-256(letter_tier.gz || catalog.json)`.
@@ -366,24 +367,36 @@ shard carries only aligned, accepted, **ref-bearing** segments:
   `_meta.mfa_failures`).
 - **Deleted** = removed from `detailed.json` entirely (editor delete / filtered at intake).
 
-Per-verse, `project_segment_shard` keeps the canonical occasion; if no occasion reaches full
-coverage `{1..N}` it falls back to the widest-coverage occasion. Two distinct outcomes:
+Per-verse, `project_segment_shard` keeps the canonical occasion (falling back to the
+widest-coverage occasion if none reaches full coverage `{1..N}`). A **publish-time completeness
+gate** — `select_complete_verses` (`qua_shared/timestamps_dedup.py`), run by both adapters against
+the reference word counts from `surah_info` — then drops any verse whose canonical take is missing a
+reference word index. Completeness is by word **index** (`{1..N_ref}` ⊆ covered indices), mirroring
+the editor's missing-words check; verses with no known reference count are kept (fail-open). Two
+distinct drop cases:
 
-- **Whole verse gone** (its only segment, or all its segments, missing) → the verse has zero shard
-  segments → `project_segment_shard` never emits it → it is dropped from **both** the HF dataset
-  (`build_rows`: `if not tdata: continue`) and the GH tier files (`if not words: continue`).
-- **Interior gap** (a middle segment missing — kept words 1-3 + 8-10, gap at 4-7) → the verse still
-  ships. Its word/letter/segment metadata and `text_uthmani` already exclude the gap words
-  (`coverage_gap` is reported but **non-fatal** — the verse is genuinely missing those words). The
-  clip window `[verse_start, verse_end]` spans the gap, so the **audio** would otherwise carry the
-  phantom no-match audio. The **HF dataset publish excises it**: `build_rows` computes `keep_runs`
-  (`[clip_start, clip_end]` minus the no-match segment spans, via `_subtract_spans`), and
-  `_slice_chapter` stitches the kept runs with `mp3_frames.slice_frames_multi` + `_rebase_row_multi`
-  (gapless re-base; logged per reciter). A contiguous verse (one run) takes the original
-  single-slice path unchanged. The **GH release** ships timestamps relative to source URLs (no
-  embedded audio), so it leaves the gap in place — its word timestamps simply skip it.
-  Leading/trailing no-match audio is already outside `[clip_start, clip_end]` (the window spans
-  first→last kept word), so only **interior** gaps stitch.
+- **Whole verse gone** (its only segment, or all its segments, missing) → zero shard segments →
+  `project_segment_shard` never emits it.
+- **Incomplete verse** (any reference word index never recited — interior *or* trailing, e.g. a
+  10-word verse recited only through word 8, or kept words 1-3 + 8-10 with 4-7 missing) → the gate
+  drops it.
+
+Either way the verse is absent from **both** the HF dataset (no row, no audio — `build_rows`:
+`if not tdata: continue`) and the GH tier files (`if not words: continue`); `coverage_ayahs` /
+`verse_count` fall by the dropped count and each job logs the dropped refs. The editor's Segments +
+TS tabs **still show** these verses (only the published artifacts gate) so reviewers can complete or
+correct them — an intentional editor-vs-published divergence.
+
+**Interior no-match audio** is a separate, orthogonal case: a verse that *does* cover every word
+index but carries a no-match segment (empty `matched_ref`, no words) inside its
+`[verse_start, verse_end]` window — leftover/duplicated audio between recited words. It survives the
+gate. The **HF dataset publish excises it**: `build_rows` computes `keep_runs` (`[clip_start,
+clip_end]` minus the no-match segment spans, via `_subtract_spans`), and `_slice_chapter` stitches
+the kept runs with `mp3_frames.slice_frames_multi` + `_rebase_row_multi` (gapless re-base; logged
+per reciter). A contiguous verse (one run) takes the original single-slice path unchanged. The **GH
+release** ships timestamps relative to source URLs (no embedded audio), so it leaves the no-match
+span in place. Leading/trailing no-match audio is already outside `[clip_start, clip_end]` (the
+window spans first→last kept word), so only **interior** spans stitch.
 
 Post-mark-ready, only in-verse segments exist (the TS job blocks compound cross-verse refs), so there
 are no cross-verse dedup cases.
@@ -392,11 +405,11 @@ are no cross-verse dedup cases.
 
 Each artifact runs a fail-blocking validation pass before it is produced; the summary is persisted
 to the `gh_releases.validation_summary` / `per_recitation_releases.validation_summary` row.
-Block on: pydantic round-trip of all rows; every non-dropped verse has a contributing segment;
-`duration_ms == last_word_end - first_word_start`; `word_timestamps` sorted by `start_ms`; dropped
-verses ≤ threshold (default 0 for full reciters). Warn on: audio-slice checksum drift; TS-tab vs
-dataset-slice parity probe. Boundary checks run at cut time via
-[dataset_validation.py](../../qua_shared/dataset_validation.py); fatal violations abort the cut.
+Block on the `HARD_FAIL_KINDS` in [dataset_validation.py](../../qua_shared/dataset_validation.py):
+`word_bleed_first`, `word_bleed_last`, `duration_arithmetic`, `intra_segment_gap` — `fatal_violations`
+aborts the cut on any of these. `coverage_gap` is reported but **non-fatal**, and incomplete verses
+are gated out by `select_complete_verses` *before* validation runs, so `coverage_gap` does not fire
+for emitted verses. Warn on: audio-slice checksum drift; TS-tab vs dataset-slice parity probe.
 
 ## TS-tab vs dataset-row parity
 
@@ -406,11 +419,13 @@ byte-substring of the bucket chapter (after per-slice Xing if VBR); the dataset 
 ≤26 ms before the first word (frame snap), with word timestamps re-based. **No intentional drift** —
 if they diverge where they should match, it's a bug.
 
-**One intentional exception:** for a verse with an interior no-match gap, the dataset clip excises
-the gap audio (stitched kept runs), while the in-app TS-tab segment-clip route is unchanged and
-still plays the contiguous `[verse_start, verse_end]` window including the gap. So for those (rare)
-verses the dataset audio is shorter than the TS-tab clip by the excised gap. Word timestamps still
-agree once re-based; only the audio bytes differ.
+**One intentional exception:** for a complete verse carrying interior no-match audio, the dataset
+clip excises that audio (stitched kept runs), while the in-app TS-tab segment-clip route is unchanged
+and still plays the contiguous `[verse_start, verse_end]` window including it. So for those (rare)
+verses the dataset audio is shorter than the TS-tab clip by the excised span. Word timestamps still
+agree once re-based; only the audio bytes differ. (Verses that are *incomplete* — missing a word
+index — never reach this path; the completeness gate drops them from the published artifacts while
+the editor still shows them.)
 
 ## Event classification
 

--- a/qua_jobs/cut_release.py
+++ b/qua_jobs/cut_release.py
@@ -833,6 +833,10 @@ def main() -> int:
     # 2. Build per-recitation artifacts and accumulate member rows.
     refs_dir = _code_root() / "data"
     surah_info = json.loads((refs_dir / "surah_info.json").read_bytes())
+    from qua_shared.auto_split_precompute import word_counts_from_surah_info
+    from qua_shared.timestamps_dedup import select_complete_verses
+
+    word_counts = word_counts_from_surah_info(surah_info)
 
     # qpc_hafs is a consumer-facing release asset. The staged image .gz is an
     # LFS pointer (HF auto-LFS by extension), so resolve the real decompressed
@@ -871,6 +875,18 @@ def main() -> int:
         if not verses:
             log.warning("  %s: no timestamps shards — skipping", slug)
             continue
+
+        # Gate incomplete verses: any verse missing a reference word index (never
+        # recited) is dropped from the release — absent from the tier JSON and
+        # excluded from coverage_ayahs. The editor/TS tab still shows them.
+        verses, dropped_incomplete = select_complete_verses(verses, word_counts)
+        if dropped_incomplete:
+            log.info(
+                "  %s: gated %d incomplete verse(s) (missing words): %s",
+                slug,
+                len(dropped_incomplete),
+                dropped_incomplete,
+            )
 
         # Load detailed.json so the intra-segment gapless check has segments
         # to validate (plan §"Boundary enforcement" — the four checks include

--- a/qua_jobs/publish_hf.py
+++ b/qua_jobs/publish_hf.py
@@ -989,6 +989,23 @@ def publish_slug(slug: str, job_id: str, *, sync_card: bool = True) -> dict:
         bucket_gz = _bucket_root() / "reference" / "qpc_hafs.json.gz"
         dk_words = json.loads(gzip.decompress(bucket_gz.read_bytes()))
 
+    # 2b. Gate incomplete verses: any verse missing a reference word index (never
+    # recited) is dropped — no row, no audio slice. Coverage falls by that count.
+    # The editor/TS tab still shows these (only the published artifacts gate).
+    from qua_shared.auto_split_precompute import word_counts_from_surah_info
+    from qua_shared.timestamps_dedup import select_complete_verses
+
+    timestamps, dropped_incomplete = select_complete_verses(
+        timestamps, word_counts_from_surah_info(surah_info)
+    )
+    if dropped_incomplete:
+        log.info(
+            "gated %d incomplete verse(s) (missing words) from %s: %s",
+            len(dropped_incomplete),
+            slug,
+            dropped_incomplete,
+        )
+
     # 3. Build rows. source_url comes from the audio manifest's chapter URLs
     # (detailed.json carries no per-entry audio field).
     detailed_by_ref = _detailed_by_ref(detailed)

--- a/qua_shared/auto_split_precompute.py
+++ b/qua_shared/auto_split_precompute.py
@@ -135,7 +135,21 @@ def _is_url(source: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _load_verse_word_counts(repo_root: Path) -> dict[tuple[int, int], int]:
+def word_counts_from_surah_info(surah_info: dict) -> dict[tuple[int, int], int]:
+    """Build the ``(surah, ayah) -> word_count`` map from a loaded surah_info dict.
+
+    ``surah_info`` is ``{surah_str: {"verses": [{"verse": int, "num_words": int},
+    ...]}}`` — the in-memory shape both publish/release jobs already hold.
+    """
+    counts: dict[tuple[int, int], int] = {}
+    for surah_str, info in surah_info.items():
+        surah = int(surah_str)
+        for v in info.get("verses", []):
+            counts[(surah, int(v["verse"]))] = int(v["num_words"])
+    return counts
+
+
+def load_verse_word_counts(repo_root: Path) -> dict[tuple[int, int], int]:
     """Build the ``(surah, ayah) -> word_count`` map from ``data/surah_info.json``.
 
     Mirrors what ``inspector.services.data_loader.get_word_counts`` returns,
@@ -144,13 +158,7 @@ def _load_verse_word_counts(repo_root: Path) -> dict[tuple[int, int], int]:
     """
     path = repo_root / "data" / "surah_info.json"
     with open(path, encoding="utf-8") as f:
-        doc = json.load(f)
-    counts: dict[tuple[int, int], int] = {}
-    for surah_str, info in doc.items():
-        surah = int(surah_str)
-        for v in info.get("verses", []):
-            counts[(surah, int(v["verse"]))] = int(v["num_words"])
-    return counts
+        return word_counts_from_surah_info(json.load(f))
 
 
 def load_chapter_urls(manifest_path: Path) -> dict[int, str]:
@@ -325,7 +333,7 @@ def run_precompute(
         log.warning("audio_manifest %s not found; URL fallback disabled", manifest_path)
 
     repo_root = repo_root or _REPO_ROOT
-    verse_word_counts = _load_verse_word_counts(repo_root)
+    verse_word_counts = load_verse_word_counts(repo_root)
 
     with open(detailed_path, encoding="utf-8") as f:
         doc = json.load(f)

--- a/qua_shared/tests/test_segment_shard_dedup.py
+++ b/qua_shared/tests/test_segment_shard_dedup.py
@@ -14,7 +14,7 @@ dedup. These tests exercise the rule on synthetic segment-array shards:
 
 from __future__ import annotations
 
-from qua_shared.timestamps_dedup import project_segment_shard
+from qua_shared.timestamps_dedup import project_segment_shard, select_complete_verses
 
 
 def _w(widx: int, s: int, e: int) -> list:
@@ -196,3 +196,79 @@ def test_verse_bounds_cover_word_and_letter_bleed():
         assert v["verse_start_ms"] <= w[1] and w[2] <= v["verse_end_ms"]
         for _ch, ls, le in w[3]:
             assert v["verse_start_ms"] <= ls and le <= v["verse_end_ms"]
+
+
+# --- select_complete_verses: publish-time gate dropping incomplete verses ---
+
+
+def _projected(*widxs: int) -> dict:
+    """A projected canonical-take value carrying one word entry per index."""
+    return {
+        "words": [_w(wi, i * 10, i * 10 + 10) for i, wi in enumerate(widxs)],
+        "verse_start_ms": 0,
+        "verse_end_ms": len(widxs) * 10,
+    }
+
+
+def test_gate_drops_verse_missing_trailing_words():
+    # 10-word verse recited only through word 8 → dropped.
+    projected = {"1:1": _projected(1, 2, 3, 4, 5, 6, 7, 8)}
+    kept, dropped = select_complete_verses(projected, {(1, 1): 10})
+    assert kept == {}
+    assert dropped == ["1:1"]
+
+
+def test_gate_drops_verse_missing_interior_word():
+    # Word 3 never recited (gap), rest present → dropped.
+    projected = {"1:1": _projected(1, 2, 4, 5, 6, 7, 8, 9, 10)}
+    kept, dropped = select_complete_verses(projected, {(1, 1): 10})
+    assert kept == {}
+    assert dropped == ["1:1"]
+
+
+def test_gate_keeps_fully_covered_verse():
+    projected = {"1:1": _projected(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)}
+    kept, dropped = select_complete_verses(projected, {(1, 1): 10})
+    assert set(kept) == {"1:1"}
+    assert dropped == []
+
+
+def test_gate_uses_word_indices_not_count():
+    # 10 word entries (a duplicated index 10) but index 3 absent → still dropped:
+    # completeness is by INDEX coverage, never by len(words) >= N_ref.
+    projected = {"1:1": _projected(1, 2, 4, 5, 6, 7, 8, 9, 10, 10)}
+    assert len(projected["1:1"]["words"]) == 10
+    kept, dropped = select_complete_verses(projected, {(1, 1): 10})
+    assert kept == {}
+    assert dropped == ["1:1"]
+
+
+def test_gate_keeps_verse_with_unknown_reference_count():
+    # No reference word count for the ref → fail-open, keep unchanged.
+    projected = {"2:5": _projected(1, 2)}
+    kept, dropped = select_complete_verses(projected, {(1, 1): 10})
+    assert kept == {"2:5": projected["2:5"]}
+    assert dropped == []
+
+
+def test_gate_drops_only_incomplete_verses_in_mixed_map():
+    projected = {
+        "1:1": _projected(1, 2, 3),  # complete (3-word verse)
+        "1:2": _projected(1, 2),  # incomplete (missing word 3)
+        "1:3": _projected(1, 2, 3, 4),  # complete (4-word verse)
+    }
+    word_counts = {(1, 1): 3, (1, 2): 3, (1, 3): 4}
+    kept, dropped = select_complete_verses(projected, word_counts)
+    assert set(kept) == {"1:1", "1:3"}
+    assert dropped == ["1:2"]
+
+
+def test_gate_through_projection_drops_trailing_incomplete():
+    # End-to-end: a shard recited only through word 8 of a 10-word verse projects
+    # to a canonical take of {1..8}, which the gate then drops.
+    shard = _shard([_seg("1:1", 0, 1000, [1, 2, 3, 4, 5, 6, 7, 8])])
+    projected = project_segment_shard(shard)
+    assert _widxs(projected["1:1"]) == [1, 2, 3, 4, 5, 6, 7, 8]
+    kept, dropped = select_complete_verses(projected, {(1, 1): 10})
+    assert kept == {}
+    assert dropped == ["1:1"]

--- a/qua_shared/timestamps_dedup.py
+++ b/qua_shared/timestamps_dedup.py
@@ -246,6 +246,47 @@ def project_segment_shard(shard: dict) -> dict[str, dict]:
     return out
 
 
+def select_complete_verses(
+    projected: dict[str, dict],
+    word_counts: dict[tuple[int, int], int],
+) -> tuple[dict[str, dict], list[str]]:
+    """Drop verses whose canonical take is missing any reference word index.
+
+    A publish-time gate layered on top of ``project_segment_shard`` (NOT part of
+    the projection — the editor/TS-tab read path must keep showing incomplete
+    verses so reviewers can fix them; only the release/dataset adapters gate).
+
+    Completeness is by word INDEX, mirroring the editor's missing-words check
+    (``inspector/services/validation/_missing.py``): a verse is complete iff
+    ``{1..N_ref}`` is a subset of the indices that carry a published word timing.
+    That covered set is the words actually present in the artifact, so it is the
+    correct "does this verse contain every word" test — it can differ marginally
+    from the matched_ref-span definition when MFA timed fewer words than a
+    segment's span. Verses with no known reference count are kept (fail-open).
+
+    Returns ``(kept_map, sorted_dropped_refs)``.
+    """
+    kept: dict[str, dict] = {}
+    dropped: list[str] = []
+    for ref, v in projected.items():
+        try:
+            surah_s, ayah_s = ref.split(":", 1)
+            key = (int(surah_s), int(ayah_s))
+        except (ValueError, AttributeError):
+            kept[ref] = v
+            continue
+        n_ref = word_counts.get(key)
+        if not n_ref:
+            kept[ref] = v
+            continue
+        covered = {int(w[0]) for w in (v.get("words") or [])}
+        if set(range(1, n_ref + 1)).issubset(covered):
+            kept[ref] = v
+        else:
+            dropped.append(ref)
+    return kept, sorted(dropped)
+
+
 def _choose_occasion(occasions: list[list[dict]], target: set[int]) -> list[dict]:
     """Pick the canonical occasion: the EARLIEST completing one.
 


### PR DESCRIPTION
@
## What

Adds a **publish-time completeness gate** that drops any *incomplete* verse — one whose recited audio is missing a reference word index (interior **or** trailing) — from **both** the HF dataset and the GH release. The reciter still publishes; the incomplete verse just doesn't appear.

- **GH release:** verse absent from the tier JSON; `coverage_ayahs` / `verse_count` fall by the dropped count.
- **HF dataset:** no row and no audio for that verse.

## Why

A verse marked **missing words** in the editor (e.g. a 10-word verse recited only through word 8) was **published anyway**, silently truncated. Root cause: `project_segment_shard` derives the verse word count from the segments themselves (`target = {1..max_recited_widx}`), so a verse missing trailing/interior words still "completes" and is emitted. Neither job consulted the reference word count — there was no gate. Downstream consumers got a partial verse with no machine-readable signal it was incomplete.

## How

- **New `select_complete_verses`** (`qua_shared/timestamps_dedup.py`): complete iff `{1..N_ref} ⊆ {covered word indices}` — **by index, not naive count** (10 word entries with index 3 absent still drops). Fail-open on unknown refs. Returns `(kept_map, sorted_dropped_refs)`.
- **Wired into both jobs** after projection, where `surah_info` is already in memory: `publish_hf.py` gates before `build_rows`; `cut_release.py` gates per-reciter `verses`. Each logs the dropped refs.
- **Word-count source**: promoted the existing loader to public `word_counts_from_surah_info(surah_info)` (+ `load_verse_word_counts`) in `qua_shared/auto_split_precompute.py` — reuses the already-loaded `surah_info`, no redundant read.

## Reviewer notes

- **Projection stays pure.** The gate is **not** inside `project_segment_shard` — that projection has a FE mirror (`occasion-dedup.ts`) under a no-drift invariant, and the editor/TS tab must keep showing incomplete verses so reviewers can fix them. Gate is adapter-only → intentional editor-vs-published divergence.
- **Supersedes interior-gap shipping.** Previously a verse missing words 4-7 shipped with its audio excised; now it's dropped. The interior **no-match audio excision** path survives but now only applies to *complete* verses carrying junk audio between recited words.
- **No abort risk.** Verified there's no "dropped verses ≤ threshold" gate in code (the doc claimed one that doesn't exist — corrected here). `coverage_gap` is non-fatal and no longer fires for emitted verses (incompletes are pre-dropped). Publishes succeed with fewer verses.

## Tests

- 8 new cases in `qua_shared/tests/test_segment_shard_dedup.py` (trailing-missing, interior-missing, fully-covered, index-not-count, unknown-ref fail-open, mixed map, end-to-end through projection).
- Full `qua_shared` suite (136) + `test_ts_roundtrip.py` green; ruff clean.
- Docs: `docs/reference/dataset-and-releases.md` contract updated.

Not yet run: live `.local/cut_sim/run_sim.py` against a reciter with a known missing-words verse.
@