### PR TITLE
fix(jobs-be): Jobs tab — batches show as RUNNING + TS history hidden

### DIFF
--- a/inspector/services/admin/jobs/base.py
+++ b/inspector/services/admin/jobs/base.py
@@ -127,18 +127,31 @@ def hf_job_url(job_id: str) -> str | None:
 # ---------------------------------------------------------------------------
 # Job-record paths: ``reciters/<slug>/jobs/<kind>/<job_id>.json`` for per-slug
 # kinds, ``jobs/_global/<kind>/<job_id>.json`` for global kinds (cut_release).
+#
+# The on-disk DIRECTORY can differ from the kind label: ``timestamps`` records
+# (written by the TS HF-Job + the legacy ``timestamps_jobs`` writer) live under
+# ``jobs/ts/`` — so the unified store reads/writes them there, not under
+# ``jobs/timestamps/``. Every other kind's dir == its label.
 # ---------------------------------------------------------------------------
+
+_KIND_DIR = {"timestamps": "ts"}
+
+
+def kind_dir(kind: str) -> str:
+    """Bucket sub-directory for a job kind (``timestamps`` → ``ts``)."""
+    return _KIND_DIR.get(kind, kind)
 
 
 def job_record_path(kind: str, slug: str | None, job_id: str) -> str:
+    d = kind_dir(kind)
     if slug is None:
-        return f"jobs/_global/{kind}/{job_id}.json"
-    return f"reciters/{slug}/jobs/{kind}/{job_id}.json"
+        return f"jobs/_global/{d}/{job_id}.json"
+    return f"reciters/{slug}/jobs/{d}/{job_id}.json"
 
 
 def legacy_job_record_path(kind: str, job_id: str) -> str:
     """Pre-2026-05 top-level path (kept for back-compat reads, never written)."""
-    return f"jobs/{kind}/{job_id}.json"
+    return f"jobs/{kind_dir(kind)}/{job_id}.json"
 
 
 # ---------------------------------------------------------------------------

--- a/inspector/services/admin/jobs/records.py
+++ b/inspector/services/admin/jobs/records.py
@@ -89,10 +89,14 @@ def read(kind: str, slug: str | None, job_id: str) -> JobRecord | None:
     data["job_id"] = data.get("job_id") or job_id
     if slug is not None:
         data.setdefault("slug", slug)
-    # Legacy TS records use ``completed_at`` (batch) — leave as extras; normalize
-    # the status to the FE vocabulary.
+    # Normalize status to the FE vocabulary. The batch record the HF Job
+    # self-writes carries a ``completed_at`` but NO top-level ``status`` — infer
+    # ``succeeded`` from the completion timestamp so a finished job never reads
+    # as ``running`` (per-member outcomes live in ``members``).
     if data.get("status"):
         data["status"] = normalize_status(data.get("status"))
+    elif data.get("ended_at") or data.get("completed_at"):
+        data["status"] = "succeeded"
     try:
         return JobRecord.model_validate(data)
     except Exception as exc:  # noqa: BLE001 — tolerate forward/legacy shapes
@@ -191,7 +195,7 @@ def list_for_slug(slug: str) -> list[JobRecord]:
     backend = base.get_backend()
     for kind in PER_SLUG_KINDS:
         try:
-            names = backend.list_dir(f"reciters/{slug}/jobs/{kind}")
+            names = backend.list_dir(f"reciters/{slug}/jobs/{base.kind_dir(kind)}")
         except Exception:
             continue
         for name in names:
@@ -216,7 +220,7 @@ def list_all() -> list[JobRecord]:
     backend = base.get_backend()
     for kind in GLOBAL_KINDS:
         try:
-            names = backend.list_dir(f"jobs/_global/{kind}")
+            names = backend.list_dir(f"jobs/_global/{base.kind_dir(kind)}")
         except Exception:
             names = []
         for name in names:

--- a/inspector/tests/services/test_jobs_records.py
+++ b/inspector/tests/services/test_jobs_records.py
@@ -175,3 +175,39 @@ def test_job_detail_surfaces_batch_members(store):
     slugs = {m.slug for m in rec.members}
     assert slugs == {"a", "b"}
     assert rec.kind == "hf_publish_batch"
+
+
+def test_statusless_completed_record_reads_succeeded(store):
+    # The batch HF Job self-writes {job_id, completed_at, members} with NO
+    # top-level status — must read as succeeded, NOT default to running.
+    path = base.job_record_path("hf_publish_batch", None, "jidNoStatus")
+    store[path] = json.dumps(
+        {
+            "job_id": "jidNoStatus",
+            "completed_at": "2026-06-09T05:00:00Z",
+            "members": [{"slug": "a", "status": "succeeded"}],
+        }
+    ).encode()
+    rec = records.read("hf_publish_batch", None, "jidNoStatus")
+    assert rec is not None
+    assert rec.status == "succeeded"
+
+
+def test_timestamps_kind_maps_to_ts_dir(store):
+    # The unified store must read/write timestamps records under jobs/ts/ (where
+    # the TS HF-Job + legacy writer put them), not jobs/timestamps/.
+    assert base.kind_dir("timestamps") == "ts"
+    assert base.job_record_path("timestamps", "reciter_x", "j").endswith(
+        "reciters/reciter_x/jobs/ts/j.json"
+    )
+    assert base.job_record_path("timestamps", None, "j") == "jobs/_global/ts/j.json"
+    assert base.job_record_path("hf_publish", "reciter_x", "j").endswith(
+        "reciters/reciter_x/jobs/hf_publish/j.json"
+    )
+    # a legacy TS record stored under jobs/ts/ is found by read + list_for_slug
+    store[base.job_record_path("timestamps", "reciter_x", "tsjob")] = json.dumps(
+        {"job_id": "tsjob", "slug": "reciter_x", "type": "ts", "status": "succeeded"}
+    ).encode()
+    rec = records.read("timestamps", "reciter_x", "tsjob")
+    assert rec is not None and rec.kind == "timestamps" and rec.status == "succeeded"
+    assert any(r.job_id == "tsjob" for r in records.list_for_slug("reciter_x"))


### PR DESCRIPTION
## Symptoms (prod)

- The admin **Jobs** tab floods with ~13 **HF batch · RUNNING · Global** rows that are actually *completed* batches.
- Historical **timestamps** jobs don't appear in the unified list at all.

## Root causes

1. **Batch records read as RUNNING.** The batch HF-Job self-writes its bucket record as `{job_id, completed_at, members}` — **no top-level `status`** — so `JobRecord` defaulted `status` to `"running"`. Every finished batch therefore showed RUNNING.
2. **TS history invisible / detail misses.** The unified store used the kind label `timestamps` as the directory (`jobs/timestamps/`), but TS records actually live under `jobs/ts/` (written by the TS HF-Job + the legacy `timestamps_jobs` writer). So `list_all`/`read` found **zero** TS records.

Verified against the live prod bucket: before, `list_all` returned only 13 batch rows all `running`; after, it returns the batches as `succeeded` plus 64 succeeded / 3 running / 6 failed timestamps jobs, and `job_detail` resolves for every record (0/86 raised).

## Fix

- `records.read`: infer `succeeded` when a record has a completion timestamp (`completed_at`/`ended_at`) but no explicit `status`.
- `base`: add `kind_dir()` mapping `timestamps → ts`; route all record paths + the `list_*` directory walks through it.
- Tests: statusless-completed → succeeded; `timestamps` kind resolves to the `ts` dir (read + `list_for_slug`).

Targeted fix off `main` (prod deploys from `main`). After merge + redeploy the flood clears and TS history appears.