### PR TITLE
perf(global-fe): virtualize catalog browse + shared search helper

### DIFF
--- a/docs/reference/frontend.md
+++ b/docs/reference/frontend.md
@@ -141,7 +141,8 @@ Recitation-animation (`lib/recitation-animation/`, mounted by `NowReciting` abov
 | `waveform-cache.ts` | Normalized-URL → peaks Map (non-reactive) |
 | `waveform-draw.ts` | Peaks → canvas draw (`drawWaveformPeaks`) |
 | `arabic-text.ts` | `stripTashkeel`, combining-mark helpers |
-| `fuzzy-match.ts` | Arabic-normalizing substring matcher (SearchableSelect, picker) |
+| `fuzzy-match.ts` | Arabic-normalizing search: memoized `normalizeArabic`, `match`, and `filterByFields` (the shared multi-field filter behind every reciter/option search bar) |
+| `list-virtualization.ts` | Pure prefix-sum windowing helpers for variable-height virtual lists (CatalogTable + SegmentsList) |
 | `surah-info.ts` | `surahInfo` data + ready promise + `surahOptionText` |
 | `grouped-reciters.ts` | Grouped reciter dropdown options |
 | `keyboard-guard.ts` | `shouldHandleKey(e, tab)` |
@@ -169,10 +170,11 @@ Entry view: public catalog browse/search/filter/play + admin controls.
 | `DashboardTab.svelte` | Root — `CatalogList` + `ReciterDetail` modal + `BottomPlayer` |
 | `views/CatalogList.svelte` | List view; filters on combinations, grouped back by reciter |
 | `views/ReciterDetail.svelte` | Reciter detail modal (flat combination table, status-priority sort) |
-| `components/CatalogTable.svelte`, `DetailHeader.svelte`, `FactsList.svelte`, `StateTimeline.svelte` | Detail/table pieces |
+| `components/CatalogTable.svelte` | Virtualized reciter list (own scroll container; windowing via `lib/utils/list-virtualization.ts`) |
+| `components/DetailHeader.svelte`, `FactsList.svelte`, `StateTimeline.svelte` | Detail/table pieces |
 | `components/ActivityRail.svelte` | Public activity feed (owner-visible delete affordance on each card) |
 | `components/RequestForm.svelte`, `submit/{SubmitWizard,StepReciter,StepSource,StepDetails}.svelte` | Request/submit flow |
-| `stores/catalog-data.ts` | Public reciter list + stats, fetched once, cached in-memory |
+| `stores/catalog-data.ts` | Full public reciter roster (paginated) + stats, cached in-memory; visibility-aware poll skips no-op refreshes |
 | `stores/dashboard-state.ts` | Filter/sort/search + detail-modal flag (mounted at root, survives modal) |
 | `stores/submit-wizard.ts` | Submit-recitation wizard FE state (3-step) |
 
@@ -196,7 +198,7 @@ Full WIP editor — trim/split/merge/re-reference, auto-validation on save.
 | Path | Role |
 |---|---|
 | `SegmentsTab.svelte` + `ShortcutsGuide.svelte` | Shell — dropdowns, filter bar, nav banner, list, CSS-var config, keyboard |
-| `components/list/` | `SegmentsList`, `SegmentWaveformCanvas` (exempt), `Navigation`, `TimeEdit`, `TimeRange`, `virtualization.ts` |
+| `components/list/` | `SegmentsList`, `SegmentWaveformCanvas` (exempt), `Navigation`, `TimeEdit`, `TimeRange` (windowing math in shared `lib/utils/list-virtualization.ts`) |
 | `components/filters/` | `FiltersBar`, `FilterCondition` |
 | `components/edit/` | `EditOverlay`, `MergePanel`, `DeletePanel` |
 | `components/history/` | `HistoryBatch`, `HistoryOp`, `HistoryArrows`, `EditChainRow` |

--- a/inspector/frontend/src/lib/components/SearchInput.svelte
+++ b/inspector/frontend/src/lib/components/SearchInput.svelte
@@ -4,29 +4,61 @@
      * inline "X of Y" count on the right. Layout (width, container) is the
      * caller's job; this component owns input chrome only.
      *
-     * Used by CombinationPicker (modal search) and CatalogList (dashboard).
-     * Add `debounceMs` if a consumer ever needs throttled input.
+     * Used by CombinationPicker (modal search), CatalogList (dashboard), and
+     * the Timestamps reciter picker. Pass `debounceMs` to coalesce keystrokes
+     * for an expensive consumer (e.g. the multi-thousand-row catalog) — the
+     * field stays responsive while the outward `input` event is throttled.
      */
     export interface SearchInputEvents { input: string; }
 </script>
 
 <script lang="ts">
-    import { createEventDispatcher } from 'svelte';
+    import { createEventDispatcher, onDestroy } from 'svelte';
 
     export let value = '';
     export let placeholder = 'Search';
     export let count: number | null = null;
     export let total: number | null = null;
     export let ariaLabel: string | undefined = undefined;
+    export let debounceMs = 0;
 
     let inputEl: HTMLInputElement | null = null;
     export function focus(): void { inputEl?.focus(); }
 
     const dispatch = createEventDispatcher<SearchInputEvents>();
 
-    function onInput(e: Event): void {
-        dispatch('input', (e.target as HTMLInputElement).value);
+    // The input shows `display` (instant on keystroke); the outward `input`
+    // event is what we debounce. `lastDispatched` tracks the value we last sent
+    // up so we can tell our own echo from an external reset of `value`.
+    let display = value;
+    let lastDispatched = value;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    // Parent changed `value` from the outside (e.g. "Clear all") — adopt it and
+    // drop any pending debounced dispatch so the stale value can't resurrect it.
+    $: if (value !== lastDispatched) {
+        display = value;
+        lastDispatched = value;
+        if (timer) { clearTimeout(timer); timer = null; }
     }
+
+    function fire(v: string): void {
+        lastDispatched = v;
+        dispatch('input', v);
+    }
+
+    function onInput(e: Event): void {
+        const v = (e.target as HTMLInputElement).value;
+        display = v;
+        if (debounceMs > 0) {
+            if (timer) clearTimeout(timer);
+            timer = setTimeout(() => { timer = null; fire(v); }, debounceMs);
+        } else {
+            fire(v);
+        }
+    }
+
+    onDestroy(() => { if (timer) clearTimeout(timer); });
 
     $: countLabel = count !== null && total !== null ? `${count} of ${total}` : null;
 </script>
@@ -44,7 +76,7 @@
         autocomplete="off"
         {placeholder}
         aria-label={ariaLabel ?? placeholder}
-        {value}
+        value={display}
         on:input={onInput}
     />
     {#if countLabel}<span class="count">{countLabel}</span>{/if}

--- a/inspector/frontend/src/lib/components/SearchableSelect.svelte
+++ b/inspector/frontend/src/lib/components/SearchableSelect.svelte
@@ -8,7 +8,7 @@
     import { createEventDispatcher, onMount } from 'svelte';
 
     import type { SelectOption } from '../types/ui';
-    import { match } from '../utils/fuzzy-match';
+    import { filterByFields } from '../utils/fuzzy-match';
 
     export let options: SelectOption[] = [];
     export let value = '';
@@ -34,9 +34,7 @@
     $: if (options) filter(inputValue);
 
     function filter(q: string): void {
-        filtered = q
-            ? options.filter(o => match(o.label, q) || match(o.group ?? '', q))
-            : [...options];
+        filtered = filterByFields(options, q, o => [o.label, o.group]);
         highlightIdx = -1;
     }
 

--- a/inspector/frontend/src/lib/components/picker/CombinationPicker.svelte
+++ b/inspector/frontend/src/lib/components/picker/CombinationPicker.svelte
@@ -32,7 +32,7 @@
     import { tagLabel } from '../../utils/axis-labels';
     import { compactCoverageLabel, compactHoursLabel } from '../../utils/delivery-label';
     import { type FacetSpec, recomputeFacets } from '../../utils/facets';
-    import { match } from '../../utils/fuzzy-match';
+    import { filterByFields } from '../../utils/fuzzy-match';
     import Modal from '../Modal.svelte';
     import ReciterChip from '../ReciterChip.svelte';
     import SearchInput from '../SearchInput.svelte';
@@ -179,12 +179,11 @@
 
     $: facetResult = recomputeFacets(bucketScoped, activeFilters, facetSpecs);
     $: facetVisible = bucketScoped.filter((_, i) => facetResult.rowVisibility[i]);
-    $: visible = search
-        ? facetVisible.filter(
-              (c) => match(c.reciter.name, search)
-                  || (c.reciter.name_ar ? match(c.reciter.name_ar, search) : false),
-          )
-        : facetVisible;
+    $: visible = filterByFields(
+        facetVisible,
+        search,
+        (c) => [c.reciter.name, c.reciter.name_ar],
+    );
 
     // Split into pinned (active claims) + groups by bucket.
     // Owners can hold multiple simultaneous claims — pin all of them.

--- a/inspector/frontend/src/lib/utils/__tests__/fuzzy-match.test.ts
+++ b/inspector/frontend/src/lib/utils/__tests__/fuzzy-match.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { match, normalizeArabic } from '../fuzzy-match';
+import { filterByFields, match, normalizeArabic } from '../fuzzy-match';
 
 describe('normalizeArabic', () => {
     // Each assertion now pins the EXPECTED canonical form rather than just
@@ -58,5 +58,42 @@ describe('match', () => {
 
     it('returns false when the substring is absent', () => {
         expect(match('Husary', 'afasy')).toBe(false);
+    });
+});
+
+describe('filterByFields', () => {
+    interface Reciter { name: string; nameAr: string | null }
+    const reciters: Reciter[] = [
+        { name: 'Mishary Al-Afasy', nameAr: 'مشاري العفاسي' },
+        { name: 'Mahmoud Al-Husary', nameAr: null },
+        { name: 'Abdul Basit', nameAr: 'عبد الباسط' },
+    ];
+    const fields = (r: Reciter) => [r.name, r.nameAr];
+
+    it('matches on the Latin field', () => {
+        expect(filterByFields(reciters, 'husary', fields)).toEqual([reciters[1]]);
+    });
+
+    it('matches on the Arabic field via normalization', () => {
+        // Query carries tashkeel + an alif variant the data lacks.
+        expect(filterByFields(reciters, 'العفاسي', fields)).toEqual([reciters[0]]);
+    });
+
+    it('returns every item for a blank query', () => {
+        expect(filterByFields(reciters, '', fields)).toHaveLength(reciters.length);
+    });
+
+    it('returns a fresh array, not the input reference', () => {
+        const out = filterByFields(reciters, '', fields);
+        expect(out).not.toBe(reciters);
+    });
+
+    it('skips nullish fields without matching them', () => {
+        // 'Husary' has a null Arabic field — an Arabic query must not match it.
+        expect(filterByFields(reciters, 'عبد', fields)).toEqual([reciters[2]]);
+    });
+
+    it('returns an empty array when nothing matches', () => {
+        expect(filterByFields(reciters, 'zzzznope', fields)).toEqual([]);
     });
 });

--- a/inspector/frontend/src/lib/utils/__tests__/list-virtualization.test.ts
+++ b/inspector/frontend/src/lib/utils/__tests__/list-virtualization.test.ts
@@ -7,7 +7,7 @@ import {
     rebuildCumHeights,
     topOfRow,
     topSpacerValue,
-} from '../virtualization';
+} from '../list-virtualization';
 
 type FakeSeg = { uid: string; index: number };
 const rowKey = (s: FakeSeg): string => s.uid;

--- a/inspector/frontend/src/lib/utils/fuzzy-match.ts
+++ b/inspector/frontend/src/lib/utils/fuzzy-match.ts
@@ -27,7 +27,23 @@ const ALIF_VARIANTS = /[أإآٱ]/g;
 const TAA_MARBUTA = /ة/g;
 const ALIF_MAKSURA = /ى/g;
 
+// Memo for normalizeArabic. Search bars re-test the same stable haystacks
+// (reciter names, option labels) on every keystroke, so caching the normalized
+// form turns each repeat into a map lookup instead of five regex passes. Inputs
+// are bounded label sets; the cap is a safety valve against unbounded growth.
+const NORMALIZE_CACHE = new Map<string, string>();
+const NORMALIZE_CACHE_CAP = 10_000;
+
 export function normalizeArabic(str: string): string {
+    const hit = NORMALIZE_CACHE.get(str);
+    if (hit !== undefined) return hit;
+    const out = normalizeRaw(str);
+    if (NORMALIZE_CACHE.size >= NORMALIZE_CACHE_CAP) NORMALIZE_CACHE.clear();
+    NORMALIZE_CACHE.set(str, out);
+    return out;
+}
+
+function normalizeRaw(str: string): string {
     return str
         .toLowerCase()
         .replace(ARABIC_DIACRITICS, '')
@@ -43,4 +59,28 @@ export function normalizeArabic(str: string): string {
 export function match(haystack: string, needle: string): boolean {
     if (!needle) return true;
     return normalizeArabic(haystack).includes(normalizeArabic(needle));
+}
+
+/**
+ * Filter ``items`` to those where any extracted field contains ``query``
+ * (Arabic-normalized substring). The needle is normalized once; each field
+ * normalization hits the shared cache. A blank query returns a copy of
+ * ``items``. ``fieldsOf`` may return nullish fields — they're skipped.
+ *
+ * Single multi-field filter for every reciter/option search bar (CatalogList,
+ * CombinationPicker, StepReciter, TimestampsFooterLeft, SearchableSelect).
+ */
+export function filterByFields<T>(
+    items: readonly T[],
+    query: string,
+    fieldsOf: (item: T) => ReadonlyArray<string | null | undefined>,
+): T[] {
+    const needle = normalizeArabic(query);
+    if (!needle) return items.slice();
+    return items.filter((item) => {
+        for (const field of fieldsOf(item)) {
+            if (field && normalizeArabic(field).includes(needle)) return true;
+        }
+        return false;
+    });
 }

--- a/inspector/frontend/src/lib/utils/list-virtualization.ts
+++ b/inspector/frontend/src/lib/utils/list-virtualization.ts
@@ -1,14 +1,15 @@
 /**
- * Pure helpers for SegmentsList virtualization.
+ * Pure, DOM-free helpers for variable-height list virtualization.
  *
- * `SegmentsList.svelte` owns the `heights: Map<rowKey, px>` cache (populated
- * by a ResizeObserver on row-group wrappers). These helpers turn that cache
- * plus `$displayedSegments` into prefix sums, window math, and spacer sizes —
- * without touching the DOM or Svelte. Tested directly in
- * `__tests__/virtualization.test.ts`.
+ * Generic over the row type: a consumer owns a `heights: Map<rowKey, px>` cache
+ * (populated by a ResizeObserver on row wrappers) and feeds it plus its row
+ * array here to get prefix sums, window math, and spacer sizes. Used by the
+ * Segments list (`SegmentsList.svelte`) and the Dashboard catalog
+ * (`CatalogTable.svelte`). Tested directly in
+ * `__tests__/list-virtualization.test.ts`.
  *
  * Why prefix sums instead of a rolling-average row height: any row's height
- * change only moves rows *after* it in the prefix sum, so a single card
+ * change only moves rows *after* it in the prefix sum, so a single row
  * changing size never translates rows above it. The rolling-average approach
  * did — that was the "segment card shakes vertically" bug.
  */

--- a/inspector/frontend/src/tabs/dashboard/DashboardTab.svelte
+++ b/inspector/frontend/src/tabs/dashboard/DashboardTab.svelte
@@ -49,11 +49,16 @@
 </div>
 
 <style>
-    .dash {
-        min-height: 60vh;
-        /* Reserve the footer height plus the now-reciting section (0 when it's
-         *  hidden — NowReciting sets the var) so content never hides behind the
-         *  shell-owned footer. */
-        padding-bottom: calc(var(--player-h, 72px) + var(--now-reciting-h, 0px));
+    /* Desktop: CatalogList bounds its own columns to fit above the fixed
+       player, so the page itself doesn't scroll — no footer reservation here. */
+    .dash { padding-bottom: 0; }
+    /* Single-column: the page scrolls normally, so reserve the footer height
+       plus the now-reciting section (0 when hidden — NowReciting sets the var)
+       so content never hides behind the shell-owned footer. */
+    @media (max-width: 900px) {
+        .dash {
+            min-height: 60vh;
+            padding-bottom: calc(var(--player-h, 72px) + var(--now-reciting-h, 0px));
+        }
     }
 </style>

--- a/inspector/frontend/src/tabs/dashboard/components/ActivityRail.svelte
+++ b/inspector/frontend/src/tabs/dashboard/components/ActivityRail.svelte
@@ -150,16 +150,30 @@
 </div>
 
 <style>
+    /* Match the catalog's shared-height envelope so all three dashboard columns
+       end on the same bottom line: the admin button + notifications rail stay
+       pinned at the top, and the activity feed takes the remaining space and
+       scrolls on its own. Reverts to natural flow once the column drops out of
+       the 3-up grid (≤1280px). */
     .rail-wrap {
         position: sticky;
         top: 0;
         align-self: start;
-        max-height: 100vh;
-        overflow-y: auto;
+        height: var(--catalog-h);
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
     }
     .activity {
+        flex: 1 1 auto;
+        min-height: 0;
+        overflow-y: auto;
         padding: var(--s-5) var(--s-5);
         border-left: 1px solid var(--border-quiet);
+    }
+    @media (max-width: 1280px) {
+        .rail-wrap { height: auto; }
+        .activity { flex: none; overflow-y: visible; }
     }
     header {
         display: flex;

--- a/inspector/frontend/src/tabs/dashboard/components/CatalogTable.svelte
+++ b/inspector/frontend/src/tabs/dashboard/components/CatalogTable.svelte
@@ -9,15 +9,31 @@
 
 <script lang="ts">
     /**
-     * Catalog list. Renders one row per reciter that has at least one
-     * combination passing the active filters. Counts on each row reflect
-     * the post-filter combinations for that reciter.
+     * Catalog list — one row per reciter that has at least one combination
+     * passing the active filters. Counts on each row reflect that post-filter
+     * subset.
+     *
+     * Virtualized: only the rows in (and just around) the viewport are mounted,
+     * so the multi-thousand-row roster renders and re-filters smoothly instead
+     * of reconciling every ReciterRow on each change. The scroll container is
+     * this component's root; the parent (`CatalogList`) gives it a bounded
+     * height. Window math is the shared prefix-sum helper in
+     * `lib/utils/list-virtualization` (also used by the Segments list).
      */
-    import { createEventDispatcher } from 'svelte';
+    import { createEventDispatcher, onDestroy, onMount } from 'svelte';
 
     import ReciterRow from '../../../lib/components/ReciterRow.svelte';
+    import {
+        bottomSpacerValue,
+        findIdxAtOffset,
+        rebuildCumHeights,
+        topSpacerValue,
+    } from '../../../lib/utils/list-virtualization';
 
     export let rows: RowEntry[];
+    /** Bumped by the parent whenever the search/filter/sort inputs change, so a
+     *  freshly narrowed list opens at the top instead of a stale scroll offset. */
+    export let resetKey = '';
 
     const dispatch = createEventDispatcher<{
         open: PublicReciter;
@@ -27,6 +43,135 @@
     function isPlayable(d: PublicDelivery): boolean {
         return d.audio_category !== 'by_ayah';
     }
+
+    // ---- Virtualization ---------------------------------------------------
+    /** Fallback row height (px) before any row mounts and we measure the real
+     *  thing. A touch over a typical row so the first paint over-renders rather
+     *  than leaving a gap. */
+    const FALLBACK_ROW_HEIGHT = 64;
+    /** Rows rendered above/below the viewport to absorb fast-scroll bursts. */
+    const BUFFER_ROWS = 12;
+    /** Skip virtualization below this count — small lists are cheap to render
+     *  whole and the spacer/observer overhead isn't worth it. */
+    const VIRTUALIZE_THRESHOLD = 60;
+
+    let listEl: HTMLDivElement | undefined;
+    let scrollTop = 0;
+    let viewportHeight = 600;
+
+    // `heights` maps rowKey → measured wrapper height; `cumHeights` is the
+    // prefix sum (cum[i] = px offset of row i's top); `estimateHeight` is the
+    // running mean used for not-yet-measured rows. See list-virtualization.ts.
+    const heights = new Map<string, number>();
+    let cumHeights: number[] = [0];
+    let estimateHeight = FALLBACK_ROW_HEIGHT;
+    let _measuredCount = 0;
+    let _measuredSum = 0;
+
+    const rowKey = (row: RowEntry): string => row.reciter.reciter_id;
+
+    let scrollRaf: number | null = null;
+    function onScroll(): void {
+        if (scrollRaf !== null) return;
+        scrollRaf = requestAnimationFrame(() => {
+            scrollRaf = null;
+            if (!listEl) return;
+            scrollTop = listEl.scrollTop;
+            viewportHeight = listEl.clientHeight;
+        });
+    }
+
+    // One observer watches each row wrapper; a second keeps `viewportHeight`
+    // fresh on container resize. On a height change we rebuild the prefix sum
+    // and, if the row sits above the window, compensate scrollTop so visible
+    // content doesn't jump (scroll anchoring).
+    const rowObserver = typeof ResizeObserver !== 'undefined'
+        ? new ResizeObserver(_handleRowResize)
+        : null;
+    const containerObserver = typeof ResizeObserver !== 'undefined'
+        ? new ResizeObserver(() => { if (listEl) viewportHeight = listEl.clientHeight; })
+        : null;
+
+    function _handleRowResize(entries: ResizeObserverEntry[]): void {
+        if (entries.length === 0) return;
+        const oldTop = topSpacerValue(cumHeights, startIdx, -1, rows, rowKey, heights, estimateHeight);
+        let changed = false;
+        for (const entry of entries) {
+            const el = entry.target as HTMLElement & { __rowKey?: string };
+            const key = el.__rowKey;
+            if (!key) continue;
+            const box = entry.borderBoxSize?.[0];
+            const h = box !== undefined ? box.blockSize : entry.contentRect.height;
+            if (h <= 0) continue;
+            const prev = heights.get(key);
+            if (prev !== undefined && Math.abs(prev - h) < 0.5) continue;
+            heights.set(key, h);
+            if (prev === undefined) { _measuredCount++; _measuredSum += h; }
+            else { _measuredSum += h - prev; }
+            estimateHeight = _measuredCount > 0 ? _measuredSum / _measuredCount : FALLBACK_ROW_HEIGHT;
+            changed = true;
+        }
+        if (!changed) return;
+        cumHeights = rebuildCumHeights(rows, rowKey, heights, estimateHeight);
+        const newTop = topSpacerValue(cumHeights, startIdx, -1, rows, rowKey, heights, estimateHeight);
+        const delta = newTop - oldTop;
+        if (delta !== 0 && listEl) {
+            listEl.scrollTop += delta;
+            scrollTop = listEl.scrollTop;
+        }
+    }
+
+    /** Svelte action: register a row wrapper with the observer. The wrapper
+     *  carries its rowKey as a property so the callback can look it up. */
+    function observeRow(node: HTMLElement, key: string) {
+        (node as HTMLElement & { __rowKey?: string }).__rowKey = key;
+        rowObserver?.observe(node);
+        return {
+            update(newKey: string): void {
+                (node as HTMLElement & { __rowKey?: string }).__rowKey = newKey;
+            },
+            destroy(): void { rowObserver?.unobserve(node); },
+        };
+    }
+
+    onMount(() => {
+        if (listEl) {
+            viewportHeight = listEl.clientHeight;
+            containerObserver?.observe(listEl);
+        }
+    });
+    onDestroy(() => {
+        if (scrollRaf !== null) cancelAnimationFrame(scrollRaf);
+        rowObserver?.disconnect();
+        containerObserver?.disconnect();
+    });
+
+    // Rebuild the prefix sum whenever the row set changes (filter, sort, poll).
+    $: { void rows; cumHeights = rebuildCumHeights(rows, rowKey, heights, estimateHeight); }
+
+    // A new search/filter/sort narrows the list — snap back to the top.
+    let _prevResetKey = resetKey;
+    $: if (resetKey !== _prevResetKey) {
+        _prevResetKey = resetKey;
+        scrollTop = 0;
+        if (listEl) listEl.scrollTop = 0;
+    }
+
+    $: total = rows.length;
+    $: virtualize = total > VIRTUALIZE_THRESHOLD;
+    $: startIdx = virtualize
+        ? Math.max(0, findIdxAtOffset(cumHeights, scrollTop) - BUFFER_ROWS)
+        : 0;
+    $: endIdx = virtualize
+        ? Math.min(total, findIdxAtOffset(cumHeights, scrollTop + viewportHeight) + 1 + BUFFER_ROWS)
+        : total;
+    $: visibleRows = virtualize ? rows.slice(startIdx, endIdx) : rows;
+    $: topSpacerPx = virtualize
+        ? topSpacerValue(cumHeights, startIdx, -1, rows, rowKey, heights, estimateHeight)
+        : 0;
+    $: bottomSpacerPx = virtualize
+        ? bottomSpacerValue(cumHeights, endIdx, total, -1, rows, rowKey, heights, estimateHeight)
+        : 0;
 </script>
 
 {#if rows.length === 0}
@@ -34,16 +179,24 @@
         <p>No reciters match the current filters.</p>
     </div>
 {:else}
-    <div class="catalog">
-        {#each rows as row (row.reciter.reciter_id)}
-            <ReciterRow
-                reciter={row.reciter}
-                visibleDeliveries={row.visibleDeliveries}
-                showPlay={row.visibleDeliveries.some(isPlayable)}
-                on:click={() => dispatch('open', row.reciter)}
-                on:play={() => dispatch('play', row)}
-            />
+    <div class="catalog" bind:this={listEl} on:scroll={onScroll}>
+        {#if topSpacerPx > 0}
+            <div class="cat-spacer" style="height: {topSpacerPx}px" aria-hidden="true"></div>
+        {/if}
+        {#each visibleRows as row (row.reciter.reciter_id)}
+            <div class="cat-row-group" use:observeRow={rowKey(row)}>
+                <ReciterRow
+                    reciter={row.reciter}
+                    visibleDeliveries={row.visibleDeliveries}
+                    showPlay={row.visibleDeliveries.some(isPlayable)}
+                    on:click={() => dispatch('open', row.reciter)}
+                    on:play={() => dispatch('play', row)}
+                />
+            </div>
         {/each}
+        {#if bottomSpacerPx > 0}
+            <div class="cat-spacer" style="height: {bottomSpacerPx}px" aria-hidden="true"></div>
+        {/if}
     </div>
 {/if}
 
@@ -51,6 +204,17 @@
     .catalog {
         margin-top: var(--s-2);
         border-top: 1px solid var(--border-quiet);
+        overflow-y: auto;
+        /* Filled by the parent's shared-height layout; falls back to natural
+           flow if no height envelope is set (e.g. narrow single-column). */
+        flex: 1 1 auto;
+        min-height: 0;
+    }
+    .cat-spacer { flex: 0 0 auto; }
+    @media (max-width: 900px) {
+        /* Single column: the parent's height envelope is dropped, so anchor the
+           list to a viewport-tall scroll box — keeps virtualization alive. */
+        .catalog { height: calc(100dvh - 220px); flex: none; }
     }
     .empty {
         padding: var(--s-12) var(--gutter);

--- a/inspector/frontend/src/tabs/dashboard/components/submit/StepReciter.svelte
+++ b/inspector/frontend/src/tabs/dashboard/components/submit/StepReciter.svelte
@@ -21,7 +21,7 @@
 
     import { COUNTRIES, countryByName } from '../../../../lib/utils/countries';
     import { channelDisplay, titleCaseSlug } from '../../../../lib/utils/delivery-label';
-    import { match } from '../../../../lib/utils/fuzzy-match';
+    import { filterByFields, match } from '../../../../lib/utils/fuzzy-match';
     import { catalogData } from '../../stores/catalog-data';
     import { openDetail } from '../../stores/dashboard-state';
     import { closeSubmitWizard, submitWizard } from '../../stores/submit-wizard';
@@ -36,10 +36,7 @@
         : null;
 
     function computeFiltered(rs: typeof reciters, q: string): typeof reciters {
-        if (!q) return rs.slice(0, 80);
-        return rs
-            .filter((r) => match(r.name, q) || (r.name_ar && match(r.name_ar, q)))
-            .slice(0, 80);
+        return filterByFields(rs, q, (r) => [r.name, r.name_ar]).slice(0, 80);
     }
     $: filtered = computeFiltered(reciters, $queryStore);
 

--- a/inspector/frontend/src/tabs/dashboard/stores/catalog-data.ts
+++ b/inspector/frontend/src/tabs/dashboard/stores/catalog-data.ts
@@ -1,20 +1,21 @@
 /**
- * Dashboard catalog data store — fetches the public reciter list +
+ * Dashboard catalog data store — fetches the full public reciter list +
  * stats once on first read and caches in-memory. Subsequent subscribers
  * receive the cached snapshot.
  *
- * Data is small (a few hundred reciters), so we fetch everything once
- * with limit=500 and filter client-side. The endpoint already supports
- * server-side filter+search; we choose client-side for responsiveness
- * and to keep the picker, dashboard, and detail page consistent.
+ * The whole roster (paged via `next_cursor`) is held client-side and
+ * filtered/searched in the browser: the endpoint supports server-side
+ * filter+search, but client-side keeps the dashboard, picker, and detail
+ * page consistent and lets facet counts reflect the complete catalog.
  *
  * Freshness: `startCatalogPolling()` drives a visibility-aware refresh so
  * the store tracks lifecycle transitions (e.g. a reciter flipping to
  * "available for review") without a manual reload — keeping every
  * catalog-fed surface (table, pickers, footer chip) in sync with the
  * activity rail, which polls on the same cadence. Backend
- * `/api/public/reciters` is `db_seq`-cached, so steady-state polls that
- * hit an unchanged catalog are near-free.
+ * `/api/public/reciters` is `db_seq`-cached, so steady-state polls hit an
+ * unchanged catalog; `applyPage` then skips the store write entirely so the
+ * (now-virtualized) list isn't re-reconciled for nothing.
  */
 import { get, writable } from 'svelte/store';
 
@@ -77,6 +78,7 @@ export async function loadCatalog(force = false): Promise<void> {
                 reciters,
                 stats,
             });
+            lastSnapshotSig = snapshotSig(reciters, stats);
         } catch (e) {
             catalogData.update((s) => ({
                 ...s,
@@ -95,7 +97,25 @@ const CATALOG_POLL_MS = 30_000;
 let pollTeardown: (() => void) | null = null;
 let pollRefs = 0;
 
+/** Signature of the last applied snapshot, so a poll that returns an unchanged
+ *  catalog skips the store write (and the list re-reconcile it would trigger). */
+let lastSnapshotSig: string | null = null;
+
+/** Cheap structural fingerprint: roster size + each reciter's volatile fields
+ *  (state/activity/delivery count) + the bucket stat counts. Catches every
+ *  change the UI renders without deep-comparing the full objects. */
+function snapshotSig(reciters: PublicReciter[], stats: BucketCounts): string {
+    let s = `${reciters.length}|`;
+    for (const r of reciters) {
+        s += `${r.reciter_id}:${r.last_activity ?? ''}:${r.primary_bucket}:${r.deliveries_count};`;
+    }
+    return `${s}|${JSON.stringify(stats)}`;
+}
+
 function applyPage(page: { reciters: PublicReciter[] }, stats: BucketCounts): void {
+    const sig = snapshotSig(page.reciters, stats);
+    if (sig === lastSnapshotSig) return;
+    lastSnapshotSig = sig;
     catalogData.set({ loading: false, error: null, reciters: page.reciters, stats });
 }
 

--- a/inspector/frontend/src/tabs/dashboard/views/CatalogList.svelte
+++ b/inspector/frontend/src/tabs/dashboard/views/CatalogList.svelte
@@ -36,38 +36,39 @@
     import { openSubmitWizard } from '../stores/submit-wizard';
 
     // ---- Shared-height layout --------------------------------------------
-    // The list scrolls inside its own container whose height tracks the filter
-    // rail (capped to the viewport), and the right rail matches it — so the
-    // three columns end on the same bottom line. `--catalog-h` is recomputed
-    // when the rail's natural height or the window changes.
-    const MIN_CATALOG_H = 280;
+    // The page itself never scrolls: the three columns scroll internally inside
+    // a shared height (`--catalog-h`) so they end on the same bottom line, just
+    // above the fixed player + now-reciting bar. The height is a pure CSS calc
+    // (see the style block) off the live `--player-h`/`--now-reciting-h` vars the shell
+    // maintains, so the columns reflow automatically as the now-reciting bar
+    // grows/shrinks — no JS observation of that dynamic bar. JS only feeds in the
+    // two measured inputs: the grid's top offset (header) and the filter rail's
+    // natural height (so short rails stay tight rather than filling the viewport).
     let gridEl: HTMLDivElement | undefined;
     let railMeasureEl: HTMLDivElement | undefined;
-    let catalogH = 600;
     let railObserver: ResizeObserver | null = null;
 
-    function recomputeCatalogHeight(): void {
-        if (!gridEl || !railMeasureEl) return;
-        const railH = railMeasureEl.offsetHeight;
+    function syncLayoutVars(): void {
+        if (!gridEl) return;
         const top = gridEl.getBoundingClientRect().top;
-        const cs = getComputedStyle(document.documentElement);
-        const playerH = parseFloat(cs.getPropertyValue('--player-h')) || 72;
-        const nowH = parseFloat(cs.getPropertyValue('--now-reciting-h')) || 0;
-        const budget = window.innerHeight - top - playerH - nowH - 16;
-        catalogH = Math.max(MIN_CATALOG_H, Math.min(railH || budget, budget));
+        if (top > 0) gridEl.style.setProperty('--cat-grid-top', `${top}px`);
+        if (railMeasureEl) {
+            gridEl.style.setProperty('--cat-rail-h', `${railMeasureEl.offsetHeight}px`);
+        }
     }
 
     onMount(() => {
         const stopPolling = startCatalogPolling();
-        recomputeCatalogHeight();
-        window.addEventListener('resize', recomputeCatalogHeight);
+        syncLayoutVars();
+        requestAnimationFrame(syncLayoutVars); // second pass once laid out
+        window.addEventListener('resize', syncLayoutVars);
         if (railMeasureEl && typeof ResizeObserver !== 'undefined') {
-            railObserver = new ResizeObserver(recomputeCatalogHeight);
+            railObserver = new ResizeObserver(syncLayoutVars);
             railObserver.observe(railMeasureEl);
         }
         return () => {
             stopPolling();
-            window.removeEventListener('resize', recomputeCatalogHeight);
+            window.removeEventListener('resize', syncLayoutVars);
             railObserver?.disconnect();
         };
     });
@@ -196,7 +197,7 @@
     const axisLabel = (axisKey: string): string => axisLabelOf(descriptor, axisKey);
 </script>
 
-<div class="grid" bind:this={gridEl} style="--catalog-h: {catalogH}px">
+<div class="grid" bind:this={gridEl}>
     <aside class="rail">
         <div class="rail-inner" bind:this={railMeasureEl}>
             {#if descriptor}
@@ -415,6 +416,16 @@
         grid-template-columns: 320px minmax(0, 1fr) 320px;
         gap: var(--s-6);
         padding: 0 var(--gutter) var(--s-12);
+        /* Shared column height: the smaller of the filter rail's natural height
+           and the space left between the grid top and the fixed player stack.
+           Built from the live shell vars so it reflows as the now-reciting bar
+           resizes; `--cat-grid-top` / `--cat-rail-h` are fed by JS. The trailing
+           subtractions reserve the grid's own bottom padding + a small gap. */
+        --catalog-h: max(280px, min(
+            var(--cat-rail-h, 200vh),
+            calc(100dvh - var(--cat-grid-top, 120px) - var(--player-h, 72px)
+                 - var(--now-reciting-h, 0px) - var(--s-12) - 8px)
+        ));
     }
     @media (max-width: 1280px) {
         .grid { grid-template-columns: 330px minmax(0, 1fr); }

--- a/inspector/frontend/src/tabs/dashboard/views/CatalogList.svelte
+++ b/inspector/frontend/src/tabs/dashboard/views/CatalogList.svelte
@@ -3,7 +3,7 @@
      * Dashboard list view. Filters operate on combinations (deliveries),
      * then visible combinations are grouped back by reciter for display.
      */
-    import { onMount } from 'svelte';
+    import { onDestroy, onMount } from 'svelte';
 
     import {
         type Axis,
@@ -18,7 +18,7 @@
     import { axisLabel as axisLabelOf, tagLabel as tagLabelOf } from '../../../lib/utils/axis-labels';
     import { compareDeliveries } from '../../../lib/utils/delivery-sort';
     import { type FacetSpec, recomputeFacets } from '../../../lib/utils/facets';
-    import { match } from '../../../lib/utils/fuzzy-match';
+    import { filterByFields } from '../../../lib/utils/fuzzy-match';
     import ActivityRail from '../components/ActivityRail.svelte';
     import type { RowEntry } from '../components/CatalogTable.svelte';
     import CatalogTable from '../components/CatalogTable.svelte';
@@ -35,7 +35,43 @@
     } from '../stores/dashboard-state';
     import { openSubmitWizard } from '../stores/submit-wizard';
 
-    onMount(() => startCatalogPolling());
+    // ---- Shared-height layout --------------------------------------------
+    // The list scrolls inside its own container whose height tracks the filter
+    // rail (capped to the viewport), and the right rail matches it — so the
+    // three columns end on the same bottom line. `--catalog-h` is recomputed
+    // when the rail's natural height or the window changes.
+    const MIN_CATALOG_H = 280;
+    let gridEl: HTMLDivElement | undefined;
+    let railMeasureEl: HTMLDivElement | undefined;
+    let catalogH = 600;
+    let railObserver: ResizeObserver | null = null;
+
+    function recomputeCatalogHeight(): void {
+        if (!gridEl || !railMeasureEl) return;
+        const railH = railMeasureEl.offsetHeight;
+        const top = gridEl.getBoundingClientRect().top;
+        const cs = getComputedStyle(document.documentElement);
+        const playerH = parseFloat(cs.getPropertyValue('--player-h')) || 72;
+        const nowH = parseFloat(cs.getPropertyValue('--now-reciting-h')) || 0;
+        const budget = window.innerHeight - top - playerH - nowH - 16;
+        catalogH = Math.max(MIN_CATALOG_H, Math.min(railH || budget, budget));
+    }
+
+    onMount(() => {
+        const stopPolling = startCatalogPolling();
+        recomputeCatalogHeight();
+        window.addEventListener('resize', recomputeCatalogHeight);
+        if (railMeasureEl && typeof ResizeObserver !== 'undefined') {
+            railObserver = new ResizeObserver(recomputeCatalogHeight);
+            railObserver.observe(railMeasureEl);
+        }
+        return () => {
+            stopPolling();
+            window.removeEventListener('resize', recomputeCatalogHeight);
+            railObserver?.disconnect();
+        };
+    });
+    onDestroy(() => railObserver?.disconnect());
 
     let descriptor: SchemaDescriptor | null = null;
     $: allDeliveries = $catalogData.reciters.flatMap((r) => r.deliveries);
@@ -55,15 +91,32 @@
     // Group visible combinations back under their reciter.
     $: rowEntries = groupByReciter($catalogData.reciters, visibleDeliveries);
 
-    $: searched = $dashboardState.search
-        ? rowEntries.filter((e) => match(e.reciter.name, $dashboardState.search)
-            || (e.reciter.name_ar && match(e.reciter.name_ar, $dashboardState.search)))
-        : rowEntries;
+    $: searched = filterByFields(
+        rowEntries,
+        $dashboardState.search,
+        (e) => [e.reciter.name, e.reciter.name_ar],
+    );
 
     $: sorted = sortRows(searched, $dashboardState.sort);
 
     // Total reciters in the catalog (search-bar denominator).
     $: totalReciters = $catalogData.reciters.length;
+
+    // Signature of the active query — changes only when the user re-filters,
+    // so CatalogTable can reset its scroll to the top without snapping back on
+    // a background catalog poll.
+    $: filterKey = [
+        $dashboardState.search,
+        $dashboardState.sort,
+        Object.entries($dashboardState.activeFilters)
+            .map(([k, v]) => `${k}:${[...v].sort().join(',')}`)
+            .sort()
+            .join('|'),
+    ].join('§');
+
+    // One collator for every name compare below — far cheaper than letting each
+    // `localeCompare` spin up its own Intl collation on every sort.
+    const collator = new Intl.Collator();
 
     function groupByReciter(
         reciters: PublicReciter[],
@@ -82,7 +135,7 @@
     function sortRows(rs: RowEntry[], sort: DashboardSort): RowEntry[] {
         const copy = [...rs];
         if (sort === 'alphabetical') {
-            copy.sort((a, b) => a.reciter.name.localeCompare(b.reciter.name));
+            copy.sort((a, b) => collator.compare(a.reciter.name, b.reciter.name));
         } else if (sort === 'combinations') {
             copy.sort((a, b) => b.visibleDeliveries.length - a.visibleDeliveries.length);
         } else if (sort === 'status') {
@@ -100,7 +153,7 @@
     function compareRecency(a: RowEntry, b: RowEntry): number {
         const ax = a.reciter.last_activity ?? '';
         const bx = b.reciter.last_activity ?? '';
-        if (ax === bx) return a.reciter.name.localeCompare(b.reciter.name);
+        if (ax === bx) return collator.compare(a.reciter.name, b.reciter.name);
         return ax < bx ? 1 : -1;
     }
 
@@ -143,16 +196,18 @@
     const axisLabel = (axisKey: string): string => axisLabelOf(descriptor, axisKey);
 </script>
 
-<div class="grid">
+<div class="grid" bind:this={gridEl} style="--catalog-h: {catalogH}px">
     <aside class="rail">
-        {#if descriptor}
-            <PickerFilterRail
-                axes={descriptor.axes}
-                activeFilters={$dashboardState.activeFilters}
-                perFacetCounts={facetResult.perFacetCounts}
-                on:toggle={(e) => toggleFacet(e.detail.axis, e.detail.tag)}
-            />
-        {/if}
+        <div class="rail-inner" bind:this={railMeasureEl}>
+            {#if descriptor}
+                <PickerFilterRail
+                    axes={descriptor.axes}
+                    activeFilters={$dashboardState.activeFilters}
+                    perFacetCounts={facetResult.perFacetCounts}
+                    on:toggle={(e) => toggleFacet(e.detail.axis, e.detail.tag)}
+                />
+            {/if}
+        </div>
     </aside>
 
     <section class="body">
@@ -164,6 +219,7 @@
                         placeholder="Search reciters"
                         count={sorted.length}
                         total={totalReciters}
+                        debounceMs={120}
                         on:input={(e) => setSearch(e.detail)}
                     />
                 </div>
@@ -233,6 +289,7 @@
 
             <CatalogTable
                 rows={sorted}
+                resetKey={filterKey}
                 on:open={(e) => openDetail(e.detail.reciter_id)}
                 on:play={(e) => onPlay(e.detail)}
             />
@@ -365,14 +422,29 @@
     }
     @media (max-width: 900px) {
         .grid { grid-template-columns: 1fr; }
+        /* Single column: drop the shared-height envelope and let the page flow;
+           the list keeps its own viewport-tall scroll box (see CatalogTable). */
+        .rail { max-height: none; overflow: visible; }
+        .body { height: auto; }
     }
     .rail {
+        max-height: var(--catalog-h);
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
+    .rail-inner {
         display: flex;
         flex-direction: column;
         gap: var(--s-5);
         padding-top: var(--s-3);
     }
-    .body { min-width: 0; }
+    .body {
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        height: var(--catalog-h);
+        min-height: 0;
+    }
     .state {
         padding: var(--s-12) 0;
         text-align: center;

--- a/inspector/frontend/src/tabs/segments/components/history/HistoryPanel.svelte
+++ b/inspector/frontend/src/tabs/segments/components/history/HistoryPanel.svelte
@@ -55,7 +55,7 @@
         findIdxAtOffset,
         rebuildCumHeights,
         topSpacerValue,
-    } from '../list/virtualization';
+    } from '../../../../lib/utils/list-virtualization';
     import EditChainRow from './EditChainRow.svelte';
     import HistoryBatch from './HistoryBatch.svelte';
     import HistoryFilters from './HistoryFilters.svelte';

--- a/inspector/frontend/src/tabs/segments/components/list/SegmentsList.svelte
+++ b/inspector/frontend/src/tabs/segments/components/list/SegmentsList.svelte
@@ -48,7 +48,7 @@
         rebuildCumHeights,
         topOfRow,
         topSpacerValue,
-    } from './virtualization';
+    } from '../../../../lib/utils/list-virtualization';
 
     export let onRestore: (() => void) | null = null;
 

--- a/inspector/frontend/src/tabs/timestamps/components/TimestampsFooterLeft.svelte
+++ b/inspector/frontend/src/tabs/timestamps/components/TimestampsFooterLeft.svelte
@@ -19,7 +19,7 @@
     import { playerContext } from '../../../lib/stores/player-context';
     import { LS_KEYS } from '../../../lib/utils/constants';
     import { combinationCompact } from '../../../lib/utils/delivery-label';
-    import { match } from '../../../lib/utils/fuzzy-match';
+    import { filterByFields } from '../../../lib/utils/fuzzy-match';
     import { catalogData } from '../../dashboard/stores/catalog-data';
     import { loadManifest } from '../services/ts_client';
     import {
@@ -47,13 +47,7 @@
 
     const entries = $derived(resolveTsDeliveries($catalogData.reciters, manifestSlugs));
     const filteredEntries = $derived(
-        pickerSearch
-            ? entries.filter(
-                  (e) =>
-                      match(e.reciter.name, pickerSearch)
-                      || (e.reciter.name_ar ? match(e.reciter.name_ar, pickerSearch) : false),
-              )
-            : entries,
+        filterByFields(entries, pickerSearch, (e) => [e.reciter.name, e.reciter.name_ar]),
     );
     const curSlug = $derived($playerContext.delivery?.slug ?? '');
     const curEntry = $derived(findTsEntryBySlug($catalogData.reciters, manifestSlugs, curSlug));


### PR DESCRIPTION
## Why

`04aa7100` (catalog browse — paginate the full reciter roster) correctly made the dashboard fetch the **whole** reciter roster instead of a single `limit=500` page, but the roster is now ~2000 reciters and filter + search became very laggy. This PR removes that regression.

The lag was **not** "2000 objects in memory" (trivial for JS). Three compounding causes, in impact order:

1. **No virtualization** — `CatalogTable` rendered one `ReciterRow` per reciter (~2000 components in the DOM); every filter/search change reconciled the whole keyed block.
2. **Redundant per-keystroke CPU** — `match()` re-ran `normalizeArabic` (5 regex passes) over *every* name on *every* keystroke; no debounce; a full `localeCompare` sort per keystroke.
3. **Poll re-render** — the 30s catalog poll always replaced the store array, reconciling the list even when the `db_seq`-cached payload was identical.

## What changed

**Virtualization** — `CatalogTable.svelte` now renders only the visible window (+overscan), reusing prefix-sum/ResizeObserver helpers relocated to the shared `lib/utils/list-virtualization.ts` (was under `segments/`; it's cross-tab now, so it belongs in `lib/`). `SegmentsList` + `HistoryPanel` updated to import from the new path.

**Shared search helper** — `lib/utils/fuzzy-match.ts` memoizes `normalizeArabic` (the actual per-keystroke win) and adds `filterByFields`, which replaces the duplicated `match(a,q) || match(b,q)` pattern in **all five** reciter/option search bars: `CatalogList`, `CombinationPicker`, `StepReciter`, `TimestampsFooterLeft`, `SearchableSelect`. `SearchInput.svelte` gains an opt-in `debounceMs` (catalog uses 120ms) that keeps the field responsive while throttling the outward event. `CatalogList` also uses a cached `Intl.Collator` for its sorts.

**No-op poll guard** — `catalog-data.ts` skips the store write when a poll returns a structurally unchanged roster.

**Dashboard layout** — the page no longer scrolls: the three columns share a height (`--catalog-h`) computed as a pure CSS `calc` off the live `--player-h`/`--now-reciting-h` shell vars, so they fill the space above the fixed player and reflow as the now-reciting bar resizes (JS only feeds the measured grid-top + filter-rail height). Each column scrolls internally; the right rail keeps notifications pinned above a scrolling activity feed. Reverts to normal page-scroll at ≤900px.

## Reviewer notes

- Branched off `04aa7100` (the pagination commit), so the PR diff is exactly this FE work — none of `main`'s later backend/jobs commits. Merge-base is `04aa7100`; conflict risk is low (FE-only files).
- `CatalogTable` is kept Svelte 4 (legacy) to mirror the proven `SegmentsList` virtualization and avoid mixing runes with the legacy parent's event API.
- Owner-only admin search bars (`ReviewerActionsPopover`, `UsersCompartment`) were intentionally left as-is.
- Pre-existing, out of scope: the `≤1280px` breakpoint hides only the activity feed (`.activity`), so `ActivityRail`'s wrapper still wraps to a second grid row at that width.

## Verification

- `npm run check` (0 errors), `npm run test` (618 pass, incl. 6 new `filterByFields` cases), `npm run lint` (clean), `npm run build` (OK).
- Live (Chrome DevTools against the real 422-reciter dev catalog): page overflow **0**; ~22 of 422 rows in the DOM; three columns align at the bottom and clear the player bar; search "afasy" → 1 row, "1 of 422", debounced; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
