### PR TITLE
fix(segs-fe): player — latency-comp playhead + footer duration fallback

### DIFF
--- a/.claude/skills/inspector-audio/references/bugs.md
+++ b/.claude/skills/inspector-audio/references/bugs.md
@@ -53,6 +53,7 @@ Symptom → likely root → first probe. Ordered by area, not severity. VBR-only
 | Cross-origin CORS failure on segment-clip | `Access-Control-Allow-Origin: *` header dropped | `routes/audio/clip.py`. Check no middleware strips it. |
 | Segment-clip 403 | `_is_known_chapter_url` rejected — URL not in the **manifest sidecar** | Confirm `audio_meta.chapter_for_url(reciter, url)` resolves (NOT `detailed.json` — its `audio` field is `""`). |
 | Segment-clip 200 / 0 bytes | ffmpeg cmd missing `-vn` → stripped ffmpeg chokes on embedded APIC cover-art (no png encoder) | Confirm `routes/audio/clip.py` cmd has `-vn`. |
+| Segments footer progress bar blank for ONE reciter (audio still plays) | Chapter audio not on the bucket → `_stream_cdn` serves a headerless MP3 → browser reports `el.duration` Infinity/NaN. The footer hides the bar when duration isn't finite. (Footer now listens for late `durationchange` + falls back to `segAllData.chapter_duration_ms_by_chapter`; also fix the data: `populate_bucket_audio.py --slug <s> --bucket prod`.) | `scripts/bucket/bucket_reciters.py --bucket prod` → compare `audio_n` vs manifest chapters. FE: `SegmentsFooter.svelte` + `footer-duration.ts::resolveChapterDurationMs`. |
 
 ## Peaks
 

--- a/.claude/skills/inspector-audio/references/frontend.md
+++ b/.claude/skills/inspector-audio/references/frontend.md
@@ -73,7 +73,11 @@ _getCtx()                     // exported for warmup/probing; AudioContext | nul
 getAudioGraph(el)             // null while ctx suspended; kicks ctx.resume()
 ensureAudioContextRunning()   // await before play after a tab switch
 cutAudio(el) / uncutAudio(el) // 5 ms ramp to 0 / 1
+getOutputLatencyMs()          // (baseLatency+outputLatency)*1000; 0 when ctx null/suspended
+displayTimeMs(mediaMs)        // mediaMs − output latency, clamped ≥0 — DISPLAY-ONLY playhead comp
 ```
+
+**Visual latency compensation (`displayTimeMs`).** `el.currentTime` is the decode/media clock; it leads the audible output by the platform output latency (`baseLatency+outputLatency`, ~20–30 ms wired, 100–300 ms BT). The Segments waveform playhead compensates by drawing at `displayTimeMs(time)` (clamped into `[seg.time_start, seg.time_end]`) inside `playback.ts::drawActivePlayhead` — the single chokepoint for both continuous + bounded draw paths. **Display-only:** never feed it to `seek`/AudioRange boundary/`onSegTimeUpdate` (those use the raw clock). Degrades to identity when the ctx is null/suspended. Segments-only today; Timestamps karaoke playhead could adopt the same helper.
 
 **Two invariants:**
 - **Graph build is gated on `ctx.state === 'running'`.** `getAudioGraph` returns `null` while suspended — building a `MediaElementAudioSourceNode` against a suspended context redirects output to a silent graph. So the kill-switch silently no-ops on the very first play (warmup may still be resuming); subsequent plays get it.

--- a/inspector/frontend/src/lib/playback/__tests__/audio-graph.test.ts
+++ b/inspector/frontend/src/lib/playback/__tests__/audio-graph.test.ts
@@ -139,3 +139,38 @@ describe('audio-graph', () => {
         expect(_ctxResume).toHaveBeenCalled();
     });
 });
+
+class LatencyCtx extends FakeAudioContext {
+    baseLatency = 0.01;
+    outputLatency = 0.04;
+}
+
+describe('output latency / displayTimeMs', () => {
+    it('getOutputLatencyMs returns (baseLatency + outputLatency) * 1000', async () => {
+        (globalThis as { AudioContext: typeof AudioContext }).AudioContext =
+            LatencyCtx as unknown as typeof AudioContext;
+        const { getOutputLatencyMs } = await import('../audio-graph');
+        expect(getOutputLatencyMs()).toBeCloseTo(50, 6);
+    });
+
+    it('displayTimeMs subtracts the output latency from the media clock', async () => {
+        (globalThis as { AudioContext: typeof AudioContext }).AudioContext =
+            LatencyCtx as unknown as typeof AudioContext;
+        const { displayTimeMs } = await import('../audio-graph');
+        expect(displayTimeMs(1000)).toBeCloseTo(950, 6);
+    });
+
+    it('displayTimeMs clamps to 0 when latency exceeds the media position', async () => {
+        (globalThis as { AudioContext: typeof AudioContext }).AudioContext =
+            LatencyCtx as unknown as typeof AudioContext;
+        const { displayTimeMs } = await import('../audio-graph');
+        expect(displayTimeMs(10)).toBe(0);
+    });
+
+    it('displayTimeMs is identity (latency 0) when no AudioContext is available', async () => {
+        delete (globalThis as { AudioContext?: typeof AudioContext }).AudioContext;
+        const { displayTimeMs, getOutputLatencyMs } = await import('../audio-graph');
+        expect(getOutputLatencyMs()).toBe(0);
+        expect(displayTimeMs(1234)).toBe(1234);
+    });
+});

--- a/inspector/frontend/src/lib/playback/audio-graph.ts
+++ b/inspector/frontend/src/lib/playback/audio-graph.ts
@@ -60,6 +60,27 @@ export function _getCtx(): AudioContext | null {
     }
 }
 
+/** Platform audio output latency in ms — `baseLatency + outputLatency` off
+ *  the shared AudioContext. This is how far the media clock (`el.currentTime`)
+ *  runs AHEAD of the sound actually reaching the speakers (~20–30 ms wired,
+ *  100–300 ms on Bluetooth). Returns 0 when the context is null/suspended or
+ *  the values aren't finite, so callers degrade to no compensation. */
+export function getOutputLatencyMs(): number {
+    const ctx = _getCtx();
+    if (!ctx) return 0;
+    const l = (ctx.baseLatency || 0) + (ctx.outputLatency || 0);
+    return Number.isFinite(l) ? l * 1000 : 0;
+}
+
+/** Media-clock ms → display ms: subtract the platform output latency so a
+ *  visual playhead tracks the AUDIBLE position instead of the decode position.
+ *  DISPLAY ONLY — never feed the result to seek / boundary / highlight logic
+ *  (those must use the raw media clock). Clamps to ≥ 0; identity when no
+ *  latency is known. */
+export function displayTimeMs(mediaTimeMs: number): number {
+    return Math.max(0, mediaTimeMs - getOutputLatencyMs());
+}
+
 /** Return the AudioGraph for `el`, building it lazily. Returns `null`
  *  when Web Audio is unavailable OR when the AudioContext isn't running yet.
  *

--- a/inspector/frontend/src/tabs/segments/components/footer/SegmentsFooter.svelte
+++ b/inspector/frontend/src/tabs/segments/components/footer/SegmentsFooter.svelte
@@ -60,6 +60,7 @@
     } from '../../stores/playback';
     import { saveButtonLabel, savePreviewVisible } from '../../stores/save';
     import { hideHistoryView, showHistoryView } from '../../utils/history/actions';
+    import { resolveChapterDurationMs } from '../../utils/playback/footer-duration';
     import { editPreviewPlaying } from '../../utils/playback/play-range';
     import {
         onSegAudioEnded,
@@ -115,6 +116,15 @@
     // subscription mounted below.
     let currentMs = 0;
 
+    // Live mirror of `<audio>.duration` (ms), kept fresh by the
+    // loadedmetadata/durationchange listeners wired in onMount. 0 while
+    // non-finite (browser hasn't resolved a streamed/headerless duration yet).
+    let elDurationMs = 0;
+    function onElDuration(): void {
+        const d = audioEl?.duration;
+        elDurationMs = d && isFinite(d) ? d * 1000 : 0;
+    }
+
     // ResizeObserver + port-subscription handles live at module scope so
     // the unified teardown in `onMount`'s return can reach them.
     let footerResizeObs: ResizeObserver | null = null;
@@ -156,6 +166,13 @@
             segAudioElement.set(audioEl);
             segPort.attachElement(audioEl);
             segPortReady.set(true);
+            // Re-read `<audio>.duration` whenever the browser resolves it.
+            // Headerless MP3s (CDN stream-through) report duration LATE via
+            // `durationchange` rather than at the first `loadedmetadata`;
+            // without this listener the footer's once-sampled read missed it
+            // and the progress bar stayed hidden.
+            audioEl.addEventListener('loadedmetadata', onElDuration);
+            audioEl.addEventListener('durationchange', onElDuration);
             playbackUnsubs = [
                 segPort.onPlay(startSegAnimation),
                 segPort.onPause(stopSegAnimation),
@@ -173,6 +190,10 @@
             document.documentElement.style.removeProperty('--seg-footer-actual-h');
             for (const off of playbackUnsubs) off();
             playbackUnsubs = [];
+            if (audioEl) {
+                audioEl.removeEventListener('loadedmetadata', onElDuration);
+                audioEl.removeEventListener('durationchange', onElDuration);
+            }
             segPort.attachElement(null);
             segPortReady.set(false);
             segAudioElement.set(null);
@@ -228,18 +249,25 @@
     // ---- Progress bar -----------------------------------------------
     // % through the currently-loaded CHAPTER audio. Under chapter-continuous
     // playback the user sees a single timeline spanning the full chapter;
-    // clicking seeks anywhere within it. `chapterDurationMs` is read from
-    // the `<audio>` element's `duration` once canplay has fired (a small
-    // reactive bump on $isMainAudioPlaying keeps it fresh after chapter
-    // swaps).
+    // clicking seeks anywhere within it. `chapterDurationMs` prefers the live
+    // `<audio>.duration` (kept fresh by the durationchange listener) but falls
+    // back to the manifest's chapter duration when the browser can't resolve
+    // one up-front (headerless CDN stream) or is playing a short VBR clip —
+    // see `resolveChapterDurationMs`.
     let chapterDurationMs = 0;
     $: {
-        // Re-read whenever playback state or chapter changes; the audio element
-        // updates duration on metadata load.
+        // Recompute on any playback/chapter change. `elDurationMs` is itself
+        // reactive (durationchange/loadedmetadata listeners); the other reads
+        // are reactive deps so this block re-runs when playback moves.
         void $isMainAudioPlaying;
         void $segData?.audio_url;
-        const dur = segPort.element?.duration;
-        chapterDurationMs = dur && isFinite(dur) ? dur * 1000 : 0;
+        const inClip = !!segPort.window?.isClip;
+        const playingCh = $playingSegmentIndex?.chapter
+            ?? ($selectedChapter ? parseInt($selectedChapter) : NaN);
+        const manifestDurMs = Number.isFinite(playingCh)
+            ? ($segAllData?.chapter_duration_ms_by_chapter?.[String(playingCh)] ?? 0)
+            : 0;
+        chapterDurationMs = resolveChapterDurationMs({ elDurationMs, inClip, manifestDurMs });
     }
 
     // Progress bar DISPLAY is always chapter-wide — `currentMs` /

--- a/inspector/frontend/src/tabs/segments/utils/playback/__tests__/footer-duration.test.ts
+++ b/inspector/frontend/src/tabs/segments/utils/playback/__tests__/footer-duration.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveChapterDurationMs } from '../footer-duration';
+
+describe('resolveChapterDurationMs', () => {
+    it('prefers the live element duration in chapter (non-clip) mode', () => {
+        expect(
+            resolveChapterDurationMs({ elDurationMs: 41_000, inClip: false, manifestDurMs: 40_500 }),
+        ).toBe(41_000);
+    });
+
+    it('falls back to the manifest duration when the element duration is non-finite (reported 0)', () => {
+        // Headerless CDN stream-through: browser hasn't resolved a duration.
+        expect(
+            resolveChapterDurationMs({ elDurationMs: 0, inClip: false, manifestDurMs: 41_000 }),
+        ).toBe(41_000);
+    });
+
+    it('uses the chapter-wide manifest duration in clip mode, ignoring the short clip duration', () => {
+        // VBR clip: el.duration is the clip (~3s) but currentMs is file-absolute,
+        // so the bar must be sized to the whole chapter.
+        expect(
+            resolveChapterDurationMs({ elDurationMs: 3_000, inClip: true, manifestDurMs: 360_000 }),
+        ).toBe(360_000);
+    });
+
+    it('returns 0 when neither source yields a duration (caller hides the bar)', () => {
+        expect(
+            resolveChapterDurationMs({ elDurationMs: 0, inClip: false, manifestDurMs: 0 }),
+        ).toBe(0);
+    });
+
+    it('returns 0 in clip mode when the manifest has no duration for the chapter', () => {
+        expect(
+            resolveChapterDurationMs({ elDurationMs: 3_000, inClip: true, manifestDurMs: 0 }),
+        ).toBe(0);
+    });
+});

--- a/inspector/frontend/src/tabs/segments/utils/playback/footer-duration.ts
+++ b/inspector/frontend/src/tabs/segments/utils/playback/footer-duration.ts
@@ -1,0 +1,30 @@
+/**
+ * Resolve the chapter duration (ms) the Segments footer uses to size its
+ * chapter-wide progress bar.
+ *
+ * The footer's progress is `currentMs / chapterDurationMs`. `currentMs` is
+ * file-absolute, so the denominator must be the full chapter's duration.
+ *
+ * Two cases break the naive `<audio>.duration` read:
+ *   - **Non-finite `el.duration`** — headerless MP3 streamed from the CDN (no
+ *     bucket file → no up-front duration) reports `Infinity`/`NaN`. Fall back
+ *     to the manifest's chapter duration.
+ *   - **VBR clip mode** — the element plays a short per-segment clip, so
+ *     `el.duration` is the CLIP length, not the chapter; using it would make
+ *     the file-absolute `currentMs` overflow the bar. Use the manifest
+ *     chapter duration instead.
+ *
+ * Returns 0 when no duration is resolvable (caller hides the progress row).
+ */
+export function resolveChapterDurationMs(opts: {
+    /** `el.duration * 1000` when finite, else 0. */
+    elDurationMs: number;
+    /** The port is playing a per-segment VBR clip (`window.isClip`). */
+    inClip: boolean;
+    /** Chapter duration from the audio manifest (`chapter_duration_ms_by_chapter`), or 0. */
+    manifestDurMs: number;
+}): number {
+    const { elDurationMs, inClip, manifestDurMs } = opts;
+    if (!inClip && elDurationMs > 0) return elDurationMs;
+    return manifestDurMs > 0 ? manifestDurMs : 0;
+}

--- a/inspector/frontend/src/tabs/segments/utils/playback/playback.ts
+++ b/inspector/frontend/src/tabs/segments/utils/playback/playback.ts
@@ -34,6 +34,7 @@
 
 import { get } from 'svelte/store';
 
+import { displayTimeMs } from '../../../../lib/playback/audio-graph';
 import { AudioRange } from '../../../../lib/playback/audio-range';
 import type { Segment } from '../../../../lib/types/view-models';
 import { type AnimationLoop,createAnimationLoop } from '../../../../lib/utils/animation';
@@ -776,10 +777,18 @@ export function drawActivePlayhead(timeMs?: number): void {
     if (!seg) return;
     const audioUrl = seg.audio_url || allData?.audio_by_chapter?.[String(active.chapter)] || '';
 
+    // Compensate the visual playhead for platform output latency: `time` is the
+    // media/decode clock, which leads the audible recitation by the OS+Web-Audio
+    // output latency. Subtract it so the playhead tracks what the user HEARS.
+    // Clamp into the segment window so it pins at the left edge during the
+    // initial latency window instead of vanishing (drawSegPlayhead skips
+    // out-of-range times). Display-only — control paths keep the raw clock.
+    const displayT = Math.min(seg.time_end, Math.max(seg.time_start, displayTimeMs(time)));
+
     // Draw the playhead on EVERY mounted twin for this (chapter, index) — main
     // list row and any accordion rows showing the same segment. Both need the
     // synchronized playhead per spec.
     for (const entry of getRowEntriesFor(active.chapter, active.index)) {
-        if (entry.canvas) drawSegPlayhead(entry.canvas, seg.time_start, seg.time_end, time, audioUrl);
+        if (entry.canvas) drawSegPlayhead(entry.canvas, seg.time_start, seg.time_end, displayT, audioUrl);
     }
 }


### PR DESCRIPTION
Draws the Segments waveform playhead at the audible position (currentTime minus AudioContext output latency) and makes the footer progress bar resilient to non-finite `el.duration` by listening for `durationchange` and falling back to the manifest chapter duration.