### PR TITLE
feat(inspector): selectable aligner model (manual + automation), default = store catalog

### DIFF
--- a/inspector/frontend/src/lib/api/admin-reviews.ts
+++ b/inspector/frontend/src/lib/api/admin-reviews.ts
@@ -152,6 +152,8 @@ export interface TimestampsJobLaunch {
 export interface TimestampsJobSettings {
     beam: number;
     probe_beams: number[];
+    // Acoustic model (catalog id); omitted/null → store default.
+    aligner_model?: string | null;
     // Affected-only regen scope (omitted → full reciter).
     chapters?: number[] | null;
     // Advanced (omitted → server defaults).
@@ -160,6 +162,20 @@ export interface TimestampsJobSettings {
     timeout?: string | null;
     batch_size?: number | null;
     download_workers?: number | null;
+}
+
+export interface AlignerModel {
+    id: string | null;
+    label: string;
+    default: boolean;
+}
+
+/** Selectable acoustic models (the store catalog) for the launch form. */
+export async function fetchAlignerModels(signal?: AbortSignal): Promise<AlignerModel[]> {
+    const resp = await fetch('/api/admin/aligner-models', { signal });
+    if (!resp.ok) return _unwrapError(resp);
+    const body = (await resp.json()) as { models: AlignerModel[] };
+    return body.models ?? [];
 }
 
 /** Live status + bounded log tail proxied from HF. */

--- a/inspector/frontend/src/lib/types/generated/schemas.ts
+++ b/inspector/frontend/src/lib/types/generated/schemas.ts
@@ -653,6 +653,7 @@ export interface AutoGenTsConfig {
   gate_by_flags?: boolean;
   beam?: number;
   probe_beams?: number;
+  aligner_model?: string | null;
 }
 /**
  * The owner's full automation configuration (one persisted blob).

--- a/inspector/frontend/src/lib/types/generated/schemas.ts
+++ b/inspector/frontend/src/lib/types/generated/schemas.ts
@@ -1192,6 +1192,7 @@ export interface JobRecord {
  */
 export interface TsJobSettings {
   beams?: number[];
+  aligner_model?: string | null;
   chapters?: number[] | null;
   workers?: number | null;
   flavor?: string | null;

--- a/inspector/frontend/src/tabs/dashboard/components/admin/releases/AutomationSection.svelte
+++ b/inspector/frontend/src/tabs/dashboard/components/admin/releases/AutomationSection.svelte
@@ -20,6 +20,15 @@
         fetchAutomation,
         saveAutomation,
     } from '../../../../../lib/api/admin-releases';
+    import { fetchAlignerModels, type AlignerModel } from '../../../../../lib/api/admin-reviews';
+
+    // Selectable acoustic models (the store catalog) for the auto-gen default.
+    let alignerModels = $state<AlignerModel[]>([]);
+    $effect(() => {
+        fetchAlignerModels()
+            .then((ms) => (alignerModels = ms))
+            .catch(() => {});
+    });
 
     // The codegen marks every defaulted field optional. The server always sends a
     // complete blob, so we normalize into a fully-required local shape on load —
@@ -35,7 +44,12 @@
         timezone: string;
     }
     interface Draft {
-        auto_gen_ts: { enabled: boolean; gate_by_comments: boolean; gate_by_flags: boolean } & BeamCfg;
+        auto_gen_ts: {
+            enabled: boolean;
+            gate_by_comments: boolean;
+            gate_by_flags: boolean;
+            aligner_model: string | null;
+        } & BeamCfg;
         stale_ts_regen: { enabled: boolean; guard_minutes: number; scope: 'full' | 'affected' } & BeamCfg;
         stale_metadata: { enabled: boolean; guard_minutes: number };
         hf_publish: SchedCfg;
@@ -55,6 +69,7 @@
                 enabled: a.enabled ?? false,
                 gate_by_comments: a.gate_by_comments ?? true,
                 gate_by_flags: a.gate_by_flags ?? true,
+                aligner_model: a.aligner_model ?? null,
                 beam: a.beam ?? 50,
                 probe_beams: a.probe_beams ?? 2,
             },
@@ -246,6 +261,18 @@
                                 <span>Skip when any segment is flagged</span>
                             </label>
                             {@render beams(draft.auto_gen_ts)}
+                            {#if alignerModels.length > 1}
+                                <label class="field wide">
+                                    <span class="lbl">model</span>
+                                    <select bind:value={draft.auto_gen_ts.aligner_model}>
+                                        {#each alignerModels as m (m.id)}
+                                            <option value={m.id}>
+                                                {m.label}{m.default ? ' (default)' : ''}
+                                            </option>
+                                        {/each}
+                                    </select>
+                                </label>
+                            {/if}
                         </div>
                     {/if}
                 </div>

--- a/inspector/frontend/src/tabs/dashboard/components/admin/releases/ReleasesTsSettings.svelte
+++ b/inspector/frontend/src/tabs/dashboard/components/admin/releases/ReleasesTsSettings.svelte
@@ -15,7 +15,9 @@
      */
     import {
         generateTimestamps,
+        fetchAlignerModels,
         type TimestampsJobSettings,
+        type AlignerModel,
     } from '../../../../../lib/api/admin-reviews';
     import type { ReleaseStatusRow } from '../../../../../lib/api/admin-releases';
     import { surahOptionText } from '../../../../../lib/utils/surah-info';
@@ -34,6 +36,17 @@
     // form state — defaults: beam 50, probe 2.
     let beam = $state(50);
     let probe = $state(2);
+    // acoustic model — null until the catalog loads, then the store default.
+    let models = $state<AlignerModel[]>([]);
+    let modelId = $state<string | null>(null);
+    $effect(() => {
+        fetchAlignerModels()
+            .then((ms) => {
+                models = ms;
+                modelId = ms.find((m) => m.default)?.id ?? ms[0]?.id ?? null;
+            })
+            .catch(() => {});
+    });
     let scope = $state<'affected' | 'full'>('affected');
     let advancedOpen = $state(false);
     let workers = $state<number | null>(null);
@@ -69,6 +82,7 @@
         const settings: TimestampsJobSettings = {
             beam,
             probe_beams: probeBeams,
+            aligner_model: modelId,
             chapters: chapters ?? null,
             workers: advancedOpen ? workers : null,
             flavor: advancedOpen && flavor.trim() ? flavor.trim() : null,
@@ -88,6 +102,16 @@
 
 <div class="ts-settings">
     <div class="beam-row">
+        {#if models.length > 1}
+            <label class="field wide">
+                <span class="lbl">model</span>
+                <select bind:value={modelId}>
+                    {#each models as m (m.id)}
+                        <option value={m.id}>{m.label}{m.default ? ' (default)' : ''}</option>
+                    {/each}
+                </select>
+            </label>
+        {/if}
         <label class="field">
             <span class="lbl">beam</span>
             <input type="number" min="1" bind:value={beam} />
@@ -180,6 +204,17 @@
     }
     .field.wide input { width: 110px; }
     .field input:focus { outline: 0; border-color: var(--accent-tint); }
+    .field select {
+        background: var(--panel);
+        border: 1px solid var(--border-quiet);
+        border-radius: var(--r-1);
+        color: var(--text-primary);
+        font: inherit;
+        font-size: var(--fs-meta);
+        padding: 3px 6px;
+        max-width: 200px;
+    }
+    .field select:focus { outline: 0; border-color: var(--accent-tint); }
 
     .adv-toggle {
         background: transparent;

--- a/inspector/routes/admin/reviews.py
+++ b/inspector/routes/admin/reviews.py
@@ -18,6 +18,7 @@ from pydantic import ValidationError
 
 from qua_shared.schemas import TsJobSettings
 from routes._admin_helpers import require_capability_or_403
+from services.admin import aligner_models as aligner_models_service
 from services.admin import reviews as reviews_service
 from services.admin import timestamps_jobs as ts_jobs
 from services.state import state as state_service
@@ -39,6 +40,13 @@ def review_detail(user, slug):
     if detail is None:
         return jsonify({"error": "unknown slug"}), 404
     return jsonify(detail)
+
+
+@admin_reviews_bp.route("/aligner-models")
+@require_capability("reviews.generate_timestamps")
+def aligner_models(user):
+    """Selectable acoustic models for the TS launch form + automation config."""
+    return jsonify({"models": aligner_models_service.list_models()})
 
 
 @admin_reviews_bp.route("/generate-timestamps/<slug>", methods=["POST"])
@@ -133,9 +141,13 @@ def _parse_ts_settings(body: dict) -> TsJobSettings:
         chapters = sorted(set(chapters_raw))
         if not chapters:
             chapters = None  # empty list = full reciter
+    aligner_model = body.get("aligner_model") or None
+    if aligner_model is not None and not isinstance(aligner_model, str):
+        raise ValueError("aligner_model must be a string (catalog id)")
     try:
         return TsJobSettings(
             beams=beams,
+            aligner_model=aligner_model,
             chapters=chapters,
             workers=workers,
             flavor=body.get("flavor") or None,

--- a/inspector/services/admin/aligner_models.py
+++ b/inspector/services/admin/aligner_models.py
@@ -32,8 +32,7 @@ def _fetch() -> list[dict]:
     default = data.get("default")
     out = []
     for m in data.get("models", []):
-        out.append({"id": m["id"], "label": m.get("label", m["id"]),
-                    "default": m["id"] == default})
+        out.append({"id": m["id"], "label": m.get("label", m["id"]), "default": m["id"] == default})
     if out and not any(m["default"] for m in out):
         out[0]["default"] = True
     return out

--- a/inspector/services/admin/aligner_models.py
+++ b/inspector/services/admin/aligner_models.py
@@ -1,0 +1,53 @@
+"""Aligner model catalog for the inspector UI.
+
+Reads the ``catalog.json`` manifest from the private model store repo
+(``MFA_MODEL_REPO``, default ``hetchyy/qua-aligner-models``) so the timestamps
+launch form + automation config can offer a model dropdown. Only the manifest
+(tiny) is fetched — never the weights. Cached in-process; a stale/unreachable
+repo degrades to a single ``default`` entry so the form still renders.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+
+logger = logging.getLogger(__name__)
+
+_MODEL_REPO = os.environ.get("MFA_MODEL_REPO", "hetchyy/qua-aligner-models")
+_TTL_S = 300
+_cache: dict[str, object] = {"at": 0.0, "models": None}
+
+
+def _fetch() -> list[dict]:
+    from huggingface_hub import hf_hub_download
+
+    path = hf_hub_download(_MODEL_REPO, "catalog.json", repo_type="model",
+                           token=os.environ.get("HF_TOKEN") or None)
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    default = data.get("default")
+    out = []
+    for m in data.get("models", []):
+        out.append({"id": m["id"], "label": m.get("label", m["id"]),
+                    "default": m["id"] == default})
+    if out and not any(m["default"] for m in out):
+        out[0]["default"] = True
+    return out
+
+
+def list_models() -> list[dict]:
+    """[{id, label, default}], default-first. Cached; never raises."""
+    now = time.time()
+    if _cache["models"] is not None and now - float(_cache["at"]) < _TTL_S:
+        return _cache["models"]  # type: ignore[return-value]
+    try:
+        models = _fetch()
+    except Exception as exc:  # noqa: BLE001 — degrade, don't break the form
+        logger.warning("aligner catalog fetch failed (%s); using default-only", exc)
+        models = _cache["models"] or [{"id": None, "label": "Default", "default": True}]
+    models = sorted(models, key=lambda m: (not m["default"], str(m["label"])))
+    _cache.update(at=now, models=models)
+    return models

--- a/inspector/services/admin/aligner_models.py
+++ b/inspector/services/admin/aligner_models.py
@@ -24,8 +24,9 @@ _cache: dict[str, object] = {"at": 0.0, "models": None}
 def _fetch() -> list[dict]:
     from huggingface_hub import hf_hub_download
 
-    path = hf_hub_download(_MODEL_REPO, "catalog.json", repo_type="model",
-                           token=os.environ.get("HF_TOKEN") or None)
+    path = hf_hub_download(
+        _MODEL_REPO, "catalog.json", repo_type="model", token=os.environ.get("HF_TOKEN") or None
+    )
     with open(path, encoding="utf-8") as fh:
         data = json.load(fh)
     default = data.get("default")

--- a/inspector/services/admin/automation/evaluators.py
+++ b/inspector/services/admin/automation/evaluators.py
@@ -152,8 +152,9 @@ def eval_auto_gen_ts(cfg: AutomationConfig, now: datetime) -> None:
         try:
             timestamps_jobs.launch(
                 slug,
-                settings=TsJobSettings(beams=_beams(c.beam, c.probe_beams),
-                                       aligner_model=c.aligner_model),
+                settings=TsJobSettings(
+                    beams=_beams(c.beam, c.probe_beams), aligner_model=c.aligner_model
+                ),
                 webhook_base=_webhook_base(),
             )
             launched.append(slug)

--- a/inspector/services/admin/automation/evaluators.py
+++ b/inspector/services/admin/automation/evaluators.py
@@ -152,7 +152,8 @@ def eval_auto_gen_ts(cfg: AutomationConfig, now: datetime) -> None:
         try:
             timestamps_jobs.launch(
                 slug,
-                settings=TsJobSettings(beams=_beams(c.beam, c.probe_beams)),
+                settings=TsJobSettings(beams=_beams(c.beam, c.probe_beams),
+                                       aligner_model=c.aligner_model),
                 webhook_base=_webhook_base(),
             )
             launched.append(slug)

--- a/inspector/services/admin/timestamps_jobs.py
+++ b/inspector/services/admin/timestamps_jobs.py
@@ -392,6 +392,10 @@ def launch(slug: str, *, settings: TsJobSettings, webhook_base: str | None = Non
     env = {
         "SLUG": slug,
         "INSPECTOR_BUCKET_MOUNT": "/data",
+        # Model store root (catalog.json + models/<id>/). The job resolves
+        # MFA_MODEL_ID against it; MFA_MODEL_PATH/DICTIONARY_PATH below are the
+        # fallback for a store-less bucket (single bare model = legacy).
+        "MFA_RUNTIME_DIR": "/aux/mfa-runtime",
         "MFA_MODEL_PATH": "/aux/mfa-runtime/quran_aligner_model.zip",
         "MFA_DICTIONARY_PATH": "/aux/mfa-runtime/dictionary.txt",
         # Legacy fallback for one release: a job picking up a stale bucket
@@ -404,6 +408,9 @@ def launch(slug: str, *, settings: TsJobSettings, webhook_base: str | None = Non
         "MKL_NUM_THREADS": "1",
         "NUMEXPR_NUM_THREADS": "1",
     }
+    # Acoustic model selection (catalog id); empty cedes to the store default.
+    if settings.aligner_model:
+        env["MFA_MODEL_ID"] = settings.aligner_model
     if settings.beams:
         env["BEAMS"] = ",".join(str(b) for b in settings.beams)
     # Affected-only regen scope — the job re-aligns just these chapters.

--- a/qua_jobs/generate_timestamps.py
+++ b/qua_jobs/generate_timestamps.py
@@ -198,8 +198,9 @@ def main() -> int:
         try:
             m = cat.resolve(model_id)
         except KeyError:
-            log.warning("aligner model %r not in catalog; using default %r",
-                        model_id, cat.default_id)
+            log.warning(
+                "aligner model %r not in catalog; using default %r", model_id, cat.default_id
+            )
             m = cat.resolve(None)
         model_path, dictionary_path = Path(m.model_path), Path(m.dictionary_path)
         log.info("aligner model %r (keep_q=%s, label=%s)", m.id, m.keep_q, m.label)

--- a/qua_jobs/generate_timestamps.py
+++ b/qua_jobs/generate_timestamps.py
@@ -184,17 +184,35 @@ def main() -> int:
     reciter_dir = mount / "reciters" / slug
     detailed = reciter_dir / "detailed.json"
 
-    # MFA runtime: explicit model + dictionary env, with a legacy fallback
-    # deriving both from MFA_APP_PATH's directory (kept one release so a
-    # launcher/staging mismatch can't strand prod).
-    model_env = os.environ.get("MFA_MODEL_PATH", "").strip()
-    dict_env = os.environ.get("MFA_DICTIONARY_PATH", "").strip()
-    if model_env and dict_env:
-        model_path, dictionary_path = Path(model_env), Path(dict_env)
-    else:
-        runtime_dir = Path(os.environ.get("MFA_APP_PATH", "/aux/mfa-runtime/app.py")).parent
-        model_path = runtime_dir / MFA_MODEL_FILENAME
-        dictionary_path = runtime_dir / MFA_DICTIONARY_FILENAME
+    # MFA runtime resolution, in priority order:
+    #   1. model catalog (MFA_RUNTIME_DIR store + MFA_MODEL_ID) — selectable model
+    #   2. explicit MFA_MODEL_PATH/DICTIONARY_PATH env
+    #   3. legacy MFA_APP_PATH dir derive
+    # keep_q is derived from the model itself by the aligner — no flag needed.
+    model_id = os.environ.get("MFA_MODEL_ID", "").strip() or None
+    model_path = dictionary_path = None
+    try:
+        from qua_sdk.components.timing.models import load_catalog
+
+        cat = load_catalog(os.environ.get("MFA_RUNTIME_DIR") or None)
+        try:
+            m = cat.resolve(model_id)
+        except KeyError:
+            log.warning("aligner model %r not in catalog; using default %r",
+                        model_id, cat.default_id)
+            m = cat.resolve(None)
+        model_path, dictionary_path = Path(m.model_path), Path(m.dictionary_path)
+        log.info("aligner model %r (keep_q=%s, label=%s)", m.id, m.keep_q, m.label)
+    except Exception as exc:  # noqa: BLE001 — degrade to the env paths
+        log.info("model catalog unavailable (%s); using env model paths", exc)
+        model_env = os.environ.get("MFA_MODEL_PATH", "").strip()
+        dict_env = os.environ.get("MFA_DICTIONARY_PATH", "").strip()
+        if model_env and dict_env:
+            model_path, dictionary_path = Path(model_env), Path(dict_env)
+        else:
+            runtime_dir = Path(os.environ.get("MFA_APP_PATH", "/aux/mfa-runtime/app.py")).parent
+            model_path = runtime_dir / MFA_MODEL_FILENAME
+            dictionary_path = runtime_dir / MFA_DICTIONARY_FILENAME
 
     if not detailed.exists():
         log.error("detailed.json not found at %s", detailed)

--- a/qua_shared/schemas/bucket/ts_job_record.py
+++ b/qua_shared/schemas/bucket/ts_job_record.py
@@ -30,6 +30,9 @@ class TsJobSettings(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     beams: list[int] = Field(default_factory=lambda: [50])
+    #: Acoustic model to align with (catalog id). ``None`` = the store's default
+    #: model. Echoed into the durable record so a run's model stays auditable.
+    aligner_model: str | None = None
     #: Regenerate only these chapters (surah numbers). ``None`` = full reciter.
     #: Untouched chapters keep their existing shards; the run merges (not
     #: clobbers) the whole-reciter ``ts_validation.json``.

--- a/qua_shared/schemas/config/automation.py
+++ b/qua_shared/schemas/config/automation.py
@@ -56,6 +56,9 @@ class AutoGenTsConfig(BaseModel):
     gate_by_flags: bool = True
     beam: int = Field(default=_DEFAULT_BEAM, ge=1)
     probe_beams: int = Field(default=_DEFAULT_PROBE_BEAMS, ge=0)
+    #: Acoustic model (catalog id) for auto-generated runs. None = store default.
+    #: The saved owner-wide preference for the new default aligner.
+    aligner_model: str | None = None
 
 
 class GhCutConfig(BaseModel):


### PR DESCRIPTION
## What

Makes **which acoustic model** a first-class, selectable choice for timestamp generation — both for a one-off manual launch and as a saved automation preference — instead of the single hardcoded `quran_aligner_model.zip`. The new full aligner **`tdb-mfa-qalqala-v2`** (QUA-25 verdict: rate-gate 84.5%, jaiz word-corruption 3.5%, beats legacy on every rule; Q/qalqala timing now explicit) becomes the **catalog default**, with `legacy` retained as a selectable rollback.

This is the inspector slice of a four-repo rollout (SDK catalog spine + timing-Space + aligner-app + offline land separately).

## How

A single **private model store** (`hetchyy/qua-aligner-models`) holds `catalog.json` + `models/<id>/{quran_aligner_model.zip, dictionary.txt}`. The SDK's new catalog loader resolves `model_id → (paths, keep_q)`; **`keep_q` is derived from the model's phone inventory**, so a Q model can't be run Q-off. Adding a model later = upload a subdir + one catalog line, no code change.

- **Schemas** — `aligner_model: str | None` on `TsJobSettings` (per-job) and `AutoGenTsConfig` (the saved automation preference; `None` ⇒ catalog default).
- **Backend** — `GET /api/admin/aligner-models` serves the catalog for the dropdowns (cached 300 s, degrades gracefully if the store is unreachable); `_parse_ts_settings` validates the choice; the job env carries `MFA_RUNTIME_DIR=/aux/mfa-runtime` + `MFA_MODEL_ID`; automation threads `aligner_model` through.
- **Job** — `generate_timestamps.py` resolves the model via the catalog (`MFA_MODEL_ID`), `keep_q` auto-derived, with a try/except fallback to the legacy env paths so a store-less deploy still works. The persisted `TsJobRecord` already echoes settings, so the chosen model shows up automatically.
- **UI** — model dropdown in `ReleasesTsSettings.svelte` (manual) and `AutomationSection.svelte` (saved default), both fed by the new endpoint, defaulting to the catalog default.

## Compatibility / rollback

- Catalog falls back to the env model everywhere, so a store-less deployment is unaffected.
- Selecting `legacy` (or flipping the catalog default) restores the previous model with no redeploy.
- The Q model adds explicit `Q` phoneme intervals; **letter timestamps are unchanged** (Q folds into its stop letter).

## Note for CI / reviewer

`schemas.ts` was hand-edited for the one added field (`AutoGenTsConfig.aligner_model`) because codegen runs server-side — please let the Pydantic→TS codegen regenerate it in CI. Frontend lint/typecheck should run on a clean `node_modules` (local pre-commit eslint hit an unrelated native-binding gap in `unrs-resolver`).

## Verification before prod

Parity smoke (`process(model_id=legacy)` == current prod output), then `qalqala-v2` letters match the 84.5% verdict + carry Q intervals; spot-listen the waqf-stop residual (arid·R / leen·R). Prod timestamp generation is unaffected until the store is mounted and the default is flipped.