### PR TITLE
fix(releases): native source URLs + chapter offsets in catalog.json

### DIFF
--- a/docs/reference/dataset-and-releases.md
+++ b/docs/reference/dataset-and-releases.md
@@ -107,9 +107,10 @@ The same predicate drives the Releases-tab buckets and the cut job's member disc
    → builds the three
    tier files (verse/word/letter, top-down), `catalog.json`, a per-recitation `manifest.json`; packs
    a deterministic `<slug>.zip`; computes `content_hash = SHA-256(letter_tier.gz || catalog.json)`.
-   `catalog.json` is built from `catalog/audio_manifest/<slug>.json::chapters[*].url`; legacy
-   sidecar metadata is tolerated here because the GH adapter only needs consumer audio URLs. A
-   GH-eligible recitation with no usable audio URLs is fatal.
+   `catalog.json` is built from `catalog/audio_manifest/<slug>.json` — each chapter's native
+   `source_url` (falling back to `url`) plus `source_offset_ms` → `chapter_offsets_ms` (see
+   [Audio policy](#audio-policy-as-built)); legacy sidecar metadata is tolerated here because the GH
+   adapter only needs consumer audio URLs. A GH-eligible recitation with no usable audio URLs is fatal.
 3. Classifies each reciter `added` / `refresh` / `unchanged` (vs prior `content_hash`) and computes
    the version (below).
 4. Builds the dataset-level `manifest.json`, `catalog.json`, and `CHANGELOG.md` (the release body — see
@@ -147,6 +148,7 @@ gh:releases/v{X.Y.Z}/
 ├── catalog.json          # dataset-level: reciter rows with audio URLs paired to timestamps
 ├── shard.py              # consumer helper (per-surah file splitter)
 ├── check_updates.py      # consumer helper (per-reciter update check)
+├── download_audio.py     # consumer helper (fetch source audio @ aligned CBR encode)
 ├── surah_info.json       # static reference
 ├── qpc_hafs.json         # static reference (mushaf text)
 ├── letter_vocab_hafs_qpc.csv  # letter-tier char alphabet (42 tokens): char,codepoint,name
@@ -192,6 +194,24 @@ from those URLs and read timestamps relative to those exact files. The fuller
 `redistribution_policy` registry (cdn_link / embedded_consent /
 internal_only) described in early design is **not implemented** — revisit if embedded-audio
 releases become a real requirement.
+
+**Native source + offsets (combined non-CDN sources).** `chapter_urls[ch]` is the **native** source
+URL — for a playlist intake (one YouTube/Drive file serving several chapters) the audio manifest
+stores a per-chapter *bucket* path in `chapters[ch].url` and the real source in `source_url`; the cut
+surfaces `source_url` (`cut_release._audio_sources_from_manifest`, mirroring `publish_hf`'s per-row
+resolution) so the release never leaks an internal bucket URL. When one source serves several chapters
+(or a single file has a trimmed lead-in), `audio.chapter_offsets_ms[ch]` carries that chapter's start
+offset inside its source — the same value the HF dataset persists as `source_offset_ms`. Map a release
+tier-file timestamp into the source file with `source_ms = chapter_offsets_ms.get(ch, 0) + tier_ms`.
+`chapter_offsets_ms` is **omitted from the JSON when empty** (model_serializer on `ReleaseCatalogAudio`),
+so CDN by-surah catalogs stay byte-stable and their `content_hash` doesn't churn.
+
+**`download_audio.py`** (release asset, `qua_jobs/download_audio.py`) fetches a reciter's source audio
+re-encoded to the alignment profile (192 kbps CBR / 44.1 kHz / mono by default; configurable). It reads
+`catalog.json` and offers `--format chapters` (one offset-0 file per surah — splits a combined file at
+the chapter offsets) or `--format original` (the source files as published + a `download_map.json` of
+chapter→file+offset). Uses `yt-dlp` + `ffmpeg` for YouTube/Drive, fails loud with install hints when a
+tool is missing. Staged like the other helpers (`base.REQUIRED_ENTRYPOINTS`) and uploaded by the cut.
 
 ### `manifest.json` (dataset-level)
 

--- a/docs/templates/release_body.md
+++ b/docs/templates/release_body.md
@@ -23,9 +23,7 @@ The release-level `manifest.json` and `catalog.json` index the whole release; ea
 
 ## How audio and timestamps pair
 
-`catalog.json` contains the audio URLs for each recitation, and every timestamp value is milliseconds relative to that matching source audio.
-
-The verse-tier entry `"1:1": [0, 2831]` means ayah 1:1 starts at `0 ms` and ends at `2831 ms` within surah 1's audio file.
+`catalog.json` contains the audio URLs for each recitation which can be streamed/downloaded directly, and every timestamp value is milliseconds relative to that matching source audio.
 
 **Combined sources.** Most reciters serve one audio file per chapter, so each chapter's timestamps start at `0 ms` of its file. Some non-CDN sources (a YouTube video or Drive file holding several surahs) instead serve **one file for many chapters**. For those, `catalog.json` carries an `audio.chapter_offsets_ms` map: chapter `C`'s timestamps are relative to `chapter_offsets_ms[C]` inside `chapter_urls[C]`, i.e. `source_ms = chapter_offsets_ms.get(C, 0) + timestamp_ms`.
 
@@ -39,7 +37,7 @@ python download_audio.py catalog.json --reciter ibrahim_al_akhdar_drive
 python download_audio.py catalog.json --reciter ibrahim_al_akhdar_drive --format original
 ```
 
-It uses `yt-dlp` + `ffmpeg` for YouTube/Drive sources (it tells you what to install if either is missing) and needs neither for direct CDN MP3s. `--bitrate`, `--sample-rate`, and `--channels` are configurable; they change only audio fidelity, never the timestamps.
+It uses `yt-dlp` + `ffmpeg` for YouTube/Drive sources and needs neither for direct CDN MP3s. `--bitrate`, `--sample-rate`, and `--channels` are configurable; see `--help`.
 
 ## Timestamp levels
 
@@ -56,6 +54,8 @@ Use `shard.py` when your app prefers per-surah files locally:
 ```bash
 python shard.py word_timestamps.json.gz --out-dir per_surah
 ```
+
+By design, timestamps have no gaps between them except at pauses, such that highlighting appears smooth and continuous during one breath. 
 
 ## Programmatic use
 

--- a/docs/templates/release_body.md
+++ b/docs/templates/release_body.md
@@ -11,6 +11,7 @@ Every release contains all reciters aligned up to date, not just new ones from t
 | `<recitation>.zip` | One recitation's verse, word, and letter timestamp files, plus its own `catalog.json`. |
 | `shard.py` | Optional helper that splits a large timestamp file into one JSON file per surah. |
 | `check_updates.py` | Optional helper that checks the latest release for updates to the reciters you use; add `--sync` to re-download them. |
+| `download_audio.py` | Optional helper that fetches a reciter's source audio (YouTube/Drive/CDN) re-encoded so the timestamps line up. |
 | `surah_info.json` | Surah names, ayah counts, and word counts. |
 | `qpc_hafs.json` | QPC Hafs word reference used by the word and letter indexes. |
 | `letter_vocab_hafs_qpc.csv` | Optional letter-tier character vocabulary (`char,codepoint,name`). |
@@ -25,6 +26,20 @@ The release-level `manifest.json` and `catalog.json` index the whole release; ea
 `catalog.json` contains the audio URLs for each recitation, and every timestamp value is milliseconds relative to that matching source audio.
 
 The verse-tier entry `"1:1": [0, 2831]` means ayah 1:1 starts at `0 ms` and ends at `2831 ms` within surah 1's audio file.
+
+**Combined sources.** Most reciters serve one audio file per chapter, so each chapter's timestamps start at `0 ms` of its file. Some non-CDN sources (a YouTube video or Drive file holding several surahs) instead serve **one file for many chapters**. For those, `catalog.json` carries an `audio.chapter_offsets_ms` map: chapter `C`'s timestamps are relative to `chapter_offsets_ms[C]` inside `chapter_urls[C]`, i.e. `source_ms = chapter_offsets_ms.get(C, 0) + timestamp_ms`.
+
+**Downloading source audio.** `download_audio.py` fetches a reciter's audio and re-encodes it to the same profile the alignment used (192 kbps CBR MP3, 44.1 kHz, mono by default), so the timestamps land correctly. Two layouts:
+
+```bash
+# one file per surah (001.mp3 … 114.mp3); timestamps apply directly (offset 0)
+python download_audio.py catalog.json --reciter ibrahim_al_akhdar_drive
+
+# the source files as published, plus a chapter -> file + offset map
+python download_audio.py catalog.json --reciter ibrahim_al_akhdar_drive --format original
+```
+
+It uses `yt-dlp` + `ffmpeg` for YouTube/Drive sources (it tells you what to install if either is missing) and needs neither for direct CDN MP3s. `--bitrate`, `--sample-rate`, and `--channels` are configurable; they change only audio fidelity, never the timestamps.
 
 ## Timestamp levels
 
@@ -176,7 +191,9 @@ type ReciterCatalog = {
   riwayah?: string; style?: string; channel?: string;
   audio_category?: "by_surah" | "by_ayah";
   audio: {
-    chapter_urls: Record<string, string>;   // chapter (or ayah) number -> source audio URL
+    chapter_urls: Record<string, string>;       // chapter (or ayah) number -> source audio URL
+    chapter_offsets_ms?: Record<string, number>; // present only for combined sources:
+                                                 // chapter -> ms offset within its (shared) source file
     sample_rate_hz?: number; channels?: number;
     bitrate_mode?: string; bitrate_kbps_nominal?: number;
   };

--- a/inspector/services/admin/jobs/base.py
+++ b/inspector/services/admin/jobs/base.py
@@ -372,6 +372,7 @@ REQUIRED_ENTRYPOINTS = (
     "qua_jobs/cut_release.py",
     "qua_jobs/shard.py",
     "qua_jobs/check_updates.py",
+    "qua_jobs/download_audio.py",
 )
 REQUIRED_STATIC_FILES = (
     "data/qpc_hafs.json",

--- a/qua_jobs/cut_release.py
+++ b/qua_jobs/cut_release.py
@@ -331,29 +331,48 @@ def _json_model_bytes(model) -> bytes:
 # ---------------------------------------------------------------------------
 
 
-def _audio_urls_from_manifest(slug: str, audio_manifest: dict | None) -> dict[str, str]:
-    """Return the consumer URL map from ``catalog/audio_manifest/<slug>.json``."""
+def _audio_sources_from_manifest(
+    slug: str, audio_manifest: dict | None
+) -> tuple[dict[str, str], dict[str, int]]:
+    """Return ``(chapter_urls, chapter_offsets_ms)`` from
+    ``catalog/audio_manifest/<slug>.json``.
+
+    ``chapter_urls`` is the NATIVE source URL per chapter — for a combined-file
+    intake (one YouTube/Drive source serving several chapters) the manifest
+    stores a per-chapter bucket path in ``url`` and the real source in
+    ``source_url``; we surface ``source_url`` so the release points consumers at
+    the original, not the internal bucket. ``chapter_offsets_ms`` is the
+    chapter's start offset *inside* that source (``source_offset_ms``), included
+    only when > 0 (combined files, or a single file with a trimmed lead-in).
+    Mirrors ``publish_hf.publish_slug``'s per-row resolution so the two adapters
+    agree on provenance + offset.
+    """
     if not audio_manifest:
-        return {}
+        return {}, {}
     chapters = audio_manifest.get("chapters")
     if isinstance(chapters, dict):
-        urls = {
-            key: chapter["url"].strip()
-            for key, chapter in sorted(chapters.items())
-            if (key.isdigit() or ":" in key)
-            and isinstance(chapter, dict)
-            and isinstance(chapter.get("url"), str)
-            and chapter["url"].strip()
-        }
+        urls: dict[str, str] = {}
+        offsets: dict[str, int] = {}
+        for key, chapter in sorted(chapters.items()):
+            if not (key.isdigit() or ":" in key) or not isinstance(chapter, dict):
+                continue
+            url = chapter.get("source_url") or chapter.get("url")
+            if not isinstance(url, str) or not url.strip():
+                continue
+            urls[key] = url.strip()
+            offset = int(chapter.get("source_offset_ms") or 0)
+            if offset > 0:
+                offsets[key] = offset
         if urls:
-            return urls
+            return urls, offsets
 
     # Legacy flat maps are kept as a defensive fallback for old fixtures.
-    return {
+    flat = {
         key: value.strip()
         for key, value in sorted(audio_manifest.items())
         if (key.isdigit() or ":" in key) and isinstance(value, str) and value.strip()
     }
+    return flat, {}
 
 
 def _build_catalog_json(rec: dict, audio_manifest: dict | None, verses: dict) -> bytes:
@@ -366,7 +385,7 @@ def _build_catalog_json(rec: dict, audio_manifest: dict | None, verses: dict) ->
     "what the source audio actually serves" so this is the consumer-actionable
     URL set without contraction.
     """
-    audio_urls = _audio_urls_from_manifest(rec["slug"], audio_manifest)
+    audio_urls, audio_offsets = _audio_sources_from_manifest(rec["slug"], audio_manifest)
     if not audio_urls:
         raise RuntimeError(f"{rec['slug']}: audio_manifest has no usable audio URLs")
     surahs = {key.split(":", 1)[0] for key in verses if not key.startswith("_")}
@@ -387,6 +406,7 @@ def _build_catalog_json(rec: dict, audio_manifest: dict | None, verses: dict) ->
         variant_label=rec.get("variant_label"),
         audio=ReleaseCatalogAudio(
             chapter_urls=audio_urls,
+            chapter_offsets_ms=audio_offsets,
             sample_rate_hz=rec.get("sample_rate_hz"),
             channels=rec.get("channels"),
             bitrate_mode=rec.get("bitrate_mode"),
@@ -794,6 +814,7 @@ def _preflight() -> int:
         "LICENSE",
         "qua_jobs/shard.py",
         "qua_jobs/check_updates.py",
+        "qua_jobs/download_audio.py",
     ):
         if not (code_dir / rel).exists():
             log.error("staged file missing: %s", code_dir / rel)
@@ -1048,6 +1069,7 @@ def main() -> int:
     license_bytes = license_path.read_bytes() if license_path.exists() else b""
     shard_py = (_code_root() / "qua_jobs" / "shard.py").read_bytes()
     check_updates_py = (_code_root() / "qua_jobs" / "check_updates.py").read_bytes()
+    download_audio_py = (_code_root() / "qua_jobs" / "download_audio.py").read_bytes()
     static_files: dict[str, bytes] = {}
     si_path = refs_dir / "surah_info.json"
     if si_path.exists():
@@ -1071,6 +1093,7 @@ def main() -> int:
     uploads.append(("catalog.json", catalog_all, "application/json"))
     uploads.append(("shard.py", shard_py, "text/x-python"))
     uploads.append(("check_updates.py", check_updates_py, "text/x-python"))
+    uploads.append(("download_audio.py", download_audio_py, "text/x-python"))
     # Letter-tier character vocabulary (the 42-token external alphabet that the
     # letter_timestamps.json.gz `char` field draws from). Generated from the
     # canonical mapping module so it can never drift from the emitted data.

--- a/qua_jobs/download_audio.py
+++ b/qua_jobs/download_audio.py
@@ -220,8 +220,19 @@ def _trim_copy(src: Path, dest: Path, start_ms: int, end_ms: int | None) -> None
     cmd = [ffmpeg, "-y", "-ss", f"{start_ms / 1000:.3f}"]
     if end_ms is not None:
         cmd += ["-to", f"{end_ms / 1000:.3f}"]
-    cmd += ["-i", str(src), "-c", "copy", "-avoid_negative_ts", "make_zero",
-            "-f", "mp3", "-v", "error", str(dest)]
+    cmd += [
+        "-i",
+        str(src),
+        "-c",
+        "copy",
+        "-avoid_negative_ts",
+        "make_zero",
+        "-f",
+        "mp3",
+        "-v",
+        "error",
+        str(dest),
+    ]
     subprocess.run(cmd, check=True)
 
 

--- a/qua_jobs/download_audio.py
+++ b/qua_jobs/download_audio.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Download a recitation's source audio so release timestamps line up with it.
+
+Shipped as a release asset. The release ``catalog.json`` pairs each reciter's
+timestamps with the audio they were aligned against; for CDN reciters those are
+direct per-chapter MP3s, but for playlist sources (YouTube / Google Drive) the
+audio has to be fetched and re-encoded. This helper does that with the SAME
+encoding the alignment used — **192 kbps CBR MP3, 44.1 kHz, mono** by default —
+so a verse's ``[start_ms, end_ms]`` from the tier files lands on the right audio.
+
+It reads ``catalog.json`` (the release-level array OR a single reciter's in-zip
+``catalog.json``) and downloads one reciter's audio in one of two layouts:
+
+  --format chapters   (default) one file per surah — ``001.mp3 … 114.mp3``.
+                      Each file starts where that chapter starts, so the release
+                      timestamps apply directly (offset 0), exactly like a CDN
+                      by-surah reciter.
+
+  --format original   the source files as published — one file per distinct
+                      source URL (a YouTube video / Drive file may hold several
+                      chapters). Timestamps are then relative to each chapter's
+                      ``chapter_offsets_ms`` inside its file; a ``download_map.json``
+                      records which file + offset each chapter maps to.
+
+Both layouts re-encode to a controlled CBR so seeking is exact. Encoding params
+are flags (``--bitrate``, ``--sample-rate``, ``--channels``) — changing them
+does not move any timestamp (those are wall-clock ms), only the audio fidelity.
+
+Requires ``yt-dlp`` and ``ffmpeg`` on PATH for YouTube/Drive sources; direct CDN
+MP3s need neither. The helper tells you exactly what to install if a tool is
+missing.
+
+Examples::
+
+    # one file per surah for a YouTube reciter (default layout)
+    python download_audio.py catalog.json --reciter ibrahim_al_akhdar_drive
+
+    # the original Drive files, plus a chapter→file+offset map
+    python download_audio.py catalog.json --reciter mohammed_ayyub_drive \
+        --format original --out-dir ./ayyub
+
+    # just a few surahs, at a higher bitrate
+    python download_audio.py catalog.json --reciter mohammed_burhaji_yt \
+        --chapters 1,36,112 --bitrate 256k
+
+    # list the reciters present in a catalog
+    python download_audio.py catalog.json --list
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# yt-dlp's web client now needs a JS runtime to solve YouTube's nsig challenge;
+# the android client returns pre-signed URLs that sidestep it (no JS runtime).
+# Namespaced under youtube:, so it's inert for Drive / other sources.
+_YTDLP_FORMAT = "bestaudio/best"
+_YTDLP_EXTRACTOR_ARGS = "youtube:player_client=android,web"
+_DIRECT_AUDIO_EXTS = frozenset({".mp3", ".wav", ".flac", ".m4a", ".ogg", ".opus", ".wma", ".aac"})
+
+
+# ---------------------------------------------------------------------------
+# Friendly dependency checks.
+# ---------------------------------------------------------------------------
+
+
+class MissingTool(RuntimeError):
+    """A required external tool is not installed — message says how to get it."""
+
+
+def _require(tool: str, how: str) -> str:
+    path = shutil.which(tool)
+    if not path:
+        raise MissingTool(f"'{tool}' is required but not installed.\n  Install it with: {how}")
+    return path
+
+
+def _needs_ytdlp(url: str) -> bool:
+    from urllib.parse import urlparse
+
+    path = urlparse(url).path.split("?")[0].lower()
+    return not any(path.endswith(ext) for ext in _DIRECT_AUDIO_EXTS)
+
+
+# ---------------------------------------------------------------------------
+# Catalog parsing.
+# ---------------------------------------------------------------------------
+
+
+def _reciters_in(catalog: dict | list) -> list[dict]:
+    """Normalize a release-level catalog (``{recitations: [...]}`` or a bare
+    list) or a single per-reciter catalog object to a list of reciter dicts."""
+    if isinstance(catalog, dict) and "recitations" in catalog:
+        return list(catalog["recitations"])
+    if isinstance(catalog, list):
+        return list(catalog)
+    if isinstance(catalog, dict) and "slug" in catalog:
+        return [catalog]
+    raise ValueError("unrecognized catalog.json shape")
+
+
+def _pick_reciter(catalog: dict | list, slug: str | None) -> dict:
+    recs = _reciters_in(catalog)
+    if slug:
+        for r in recs:
+            if r.get("slug") == slug:
+                return r
+        raise ValueError(f"reciter {slug!r} not found in catalog")
+    if len(recs) == 1:
+        return recs[0]
+    names = ", ".join(sorted(r.get("slug", "?") for r in recs))
+    raise ValueError(
+        f"catalog has {len(recs)} reciters — pass --reciter <slug>. Available: {names}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Download + encode (mirrors the offline alignment pipeline's encode).
+# ---------------------------------------------------------------------------
+
+
+def _encode_cbr(src: Path, dest: Path, *, bitrate: str, sample_rate: str, channels: str) -> None:
+    """Encode ``src`` to a controlled CBR MP3. ``-vn`` drops any embedded
+    thumbnail (a cover-art stream otherwise yields a 0-byte mp3 on ffmpeg builds
+    without a PNG encoder)."""
+    ffmpeg = _require("ffmpeg", "https://ffmpeg.org/download.html (or `apt install ffmpeg`)")
+    subprocess.run(
+        [ffmpeg, "-y", "-i", str(src), "-vn", "-c:a", "libmp3lame",
+         "-b:a", bitrate, "-ar", sample_rate, "-ac", channels,
+         "-f", "mp3", "-v", "error", str(dest)],
+        check=True,
+    )
+
+
+def _download_source(url: str, *, bitrate: str, sample_rate: str, channels: str) -> Path:
+    """Fetch ``url`` and return a temp CBR MP3 path (caller owns cleanup)."""
+    out = Path(tempfile.NamedTemporaryFile(delete=False, suffix=".mp3").name)
+    if not _needs_ytdlp(url):
+        import urllib.request
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=Path(url.split("?")[0]).suffix) as tf:
+            raw = Path(tf.name)
+        req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+        with urllib.request.urlopen(req) as resp, raw.open("wb") as fh:
+            shutil.copyfileobj(resp, fh)
+        try:
+            _encode_cbr(raw, out, bitrate=bitrate, sample_rate=sample_rate, channels=channels)
+        finally:
+            raw.unlink(missing_ok=True)
+        return out
+
+    yt_dlp = _require("yt-dlp", "pip install yt-dlp")
+    src_dir = Path(tempfile.mkdtemp(prefix="qua_src_"))
+    try:
+        proc = subprocess.run(
+            [yt_dlp, "-f", _YTDLP_FORMAT, "--no-playlist",
+             "--extractor-args", _YTDLP_EXTRACTOR_ARGS,
+             "--retries", "5", "--fragment-retries", "5", "--retry-sleep", "5",
+             "--socket-timeout", "30",
+             "-o", str(src_dir / "src.%(ext)s"), "--force-overwrites", url],
+            capture_output=True, text=True,
+        )
+        srcs = [p for p in src_dir.iterdir() if p.name.startswith("src.")]
+        if proc.returncode != 0 or not srcs:
+            tail = (proc.stderr or proc.stdout or "").strip()[-400:]
+            raise RuntimeError(f"yt-dlp failed for {url}:\n{tail}")
+        _encode_cbr(srcs[0], out, bitrate=bitrate, sample_rate=sample_rate, channels=channels)
+        return out
+    finally:
+        shutil.rmtree(src_dir, ignore_errors=True)
+
+
+def _trim_copy(src: Path, dest: Path, start_ms: int, end_ms: int | None) -> None:
+    """Cut ``[start_ms, end_ms)`` from a CBR MP3 by frame copy (no re-encode).
+
+    Input-seek + ``-c copy`` snaps to the MP3 frame at/just before ``start_ms``
+    — the same frame the offline trim used, so the surviving timestamps stay
+    aligned to within one frame (~26 ms). ``end_ms=None`` keeps to end-of-file.
+    """
+    ffmpeg = _require("ffmpeg", "https://ffmpeg.org/download.html (or `apt install ffmpeg`)")
+    cmd = [ffmpeg, "-y", "-ss", f"{start_ms / 1000:.3f}"]
+    if end_ms is not None:
+        cmd += ["-to", f"{end_ms / 1000:.3f}"]
+    cmd += ["-i", str(src), "-c", "copy", "-avoid_negative_ts", "make_zero",
+            "-f", "mp3", "-v", "error", str(dest)]
+    subprocess.run(cmd, check=True)
+
+
+# ---------------------------------------------------------------------------
+# Orchestration.
+# ---------------------------------------------------------------------------
+
+
+def _chapter_windows(
+    offsets: dict[str, int], chapters: list[str]
+) -> dict[str, tuple[int, int | None]]:
+    """For each chapter on a SHARED source file, derive ``(start_ms, end_ms)``.
+
+    Chapters on the same source are contiguous, so a chapter ends where the next
+    (by offset) begins; the last runs to end-of-file (``None``). A chapter that
+    owns its file starts at its offset (a trimmed lead-in) and runs to EOF.
+    """
+    by_off = sorted(chapters, key=lambda c: offsets.get(c, 0))
+    windows: dict[str, tuple[int, int | None]] = {}
+    for i, ch in enumerate(by_off):
+        start = offsets.get(ch, 0)
+        end = offsets.get(by_off[i + 1], None) if i + 1 < len(by_off) else None
+        windows[ch] = (start, end)
+    return windows
+
+
+def download_reciter(
+    reciter: dict,
+    out_dir: Path,
+    *,
+    fmt: str,
+    bitrate: str,
+    sample_rate: str,
+    channels: str,
+    only: list[str] | None,
+) -> dict:
+    """Download one reciter's audio into ``out_dir``. Returns a download map."""
+    audio = reciter.get("audio") or {}
+    chapter_urls: dict[str, str] = audio.get("chapter_urls") or {}
+    offsets: dict[str, int] = audio.get("chapter_offsets_ms") or {}
+    if not chapter_urls:
+        raise ValueError(f"{reciter.get('slug')}: catalog has no chapter_urls")
+
+    wanted = [c for c in chapter_urls if (not only or c in only)]
+    if not wanted:
+        raise ValueError(f"no matching chapters (requested {only})")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Group the wanted chapters by their source URL (one download per source).
+    by_url: dict[str, list[str]] = {}
+    for ch in wanted:
+        by_url.setdefault(chapter_urls[ch], []).append(ch)
+
+    dl_map: dict[str, dict] = {}
+    enc = dict(bitrate=bitrate, sample_rate=sample_rate, channels=channels)
+    sources = sorted(by_url, key=lambda u: min(int(c) for c in by_url[u]))
+    for idx, url in enumerate(sources, 1):
+        chs = sorted(by_url[url], key=int)
+        print(f"[{idx}/{len(sources)}] {url}  (chapters {', '.join(chs)})")
+        src_mp3 = _download_source(url, **enc)
+        try:
+            if fmt == "original":
+                name = f"source-{idx:02d}.mp3" if len(chs) > 1 else f"{int(chs[0]):03d}.mp3"
+                shutil.copyfile(src_mp3, out_dir / name)
+                for ch in chs:
+                    dl_map[ch] = {"file": name, "offset_ms": int(offsets.get(ch, 0))}
+                print(f"    -> {name}")
+            else:  # chapters: split each chapter to its own offset-0 file
+                windows = _chapter_windows(offsets, chs)
+                for ch in chs:
+                    start, end = windows[ch]
+                    dest = out_dir / f"{int(ch):03d}.mp3"
+                    if len(chs) == 1 and start == 0:
+                        shutil.copyfile(src_mp3, dest)
+                    else:
+                        _trim_copy(src_mp3, dest, start, end)
+                    dl_map[ch] = {"file": dest.name, "offset_ms": 0}
+                    print(f"    -> {dest.name}")
+        finally:
+            src_mp3.unlink(missing_ok=True)
+
+    (out_dir / "download_map.json").write_text(
+        json.dumps(
+            {"slug": reciter.get("slug"), "format": fmt, "encode": enc, "chapters": dl_map},
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return dl_map
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Download a recitation's source audio aligned to release timestamps",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("catalog", type=Path, help="Path to catalog.json (release-level or per-reciter)")
+    p.add_argument("--reciter", help="Reciter slug (required unless the catalog has one reciter)")
+    p.add_argument("--list", action="store_true", help="List reciters in the catalog and exit")
+    p.add_argument("--format", choices=("chapters", "original"), default="chapters",
+                   dest="fmt", help="Output layout (default: chapters = one file per surah)")
+    p.add_argument("--out-dir", type=Path, help="Output directory (default: ./<slug>)")
+    p.add_argument("--chapters", help="Comma-separated chapter subset (default: all)")
+    p.add_argument("--bitrate", default="192k", help="CBR audio bitrate (default: 192k)")
+    p.add_argument("--sample-rate", default="44100", help="Sample rate Hz (default: 44100)")
+    p.add_argument("--channels", default="1", help="Channels: 1=mono, 2=stereo (default: 1)")
+    args = p.parse_args(argv)
+
+    if not args.catalog.exists():
+        print(f"error: {args.catalog} does not exist", file=sys.stderr)
+        return 2
+    try:
+        catalog = json.loads(args.catalog.read_bytes())
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"error: cannot read {args.catalog}: {exc}", file=sys.stderr)
+        return 2
+
+    if args.list:
+        for r in _reciters_in(catalog):
+            audio = r.get("audio") or {}
+            n = len(audio.get("chapter_urls") or {})
+            combined = " (combined sources)" if audio.get("chapter_offsets_ms") else ""
+            print(f"  {r.get('slug'):42s} {n} chapter(s){combined}")
+        return 0
+
+    try:
+        reciter = _pick_reciter(catalog, args.reciter)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    slug = reciter.get("slug") or "reciter"
+    out_dir = args.out_dir or Path(slug)
+    only = [c.strip() for c in args.chapters.split(",") if c.strip()] if args.chapters else None
+
+    try:
+        dl_map = download_reciter(
+            reciter, out_dir, fmt=args.fmt, bitrate=args.bitrate,
+            sample_rate=args.sample_rate, channels=args.channels, only=only,
+        )
+    except MissingTool as exc:
+        print(f"\nerror: {exc}", file=sys.stderr)
+        return 3
+    except (RuntimeError, ValueError, subprocess.CalledProcessError) as exc:
+        print(f"\nerror: {exc}", file=sys.stderr)
+        return 4
+
+    print(f"\nDone — {len(dl_map)} chapter(s) in {out_dir}/  (see download_map.json)")
+    if args.fmt == "original":
+        print("Timestamps are relative to each chapter's offset_ms within its file.")
+    else:
+        print("Each NNN.mp3 starts at its chapter — release timestamps apply directly.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qua_jobs/download_audio.py
+++ b/qua_jobs/download_audio.py
@@ -131,9 +131,26 @@ def _encode_cbr(src: Path, dest: Path, *, bitrate: str, sample_rate: str, channe
     without a PNG encoder)."""
     ffmpeg = _require("ffmpeg", "https://ffmpeg.org/download.html (or `apt install ffmpeg`)")
     subprocess.run(
-        [ffmpeg, "-y", "-i", str(src), "-vn", "-c:a", "libmp3lame",
-         "-b:a", bitrate, "-ar", sample_rate, "-ac", channels,
-         "-f", "mp3", "-v", "error", str(dest)],
+        [
+            ffmpeg,
+            "-y",
+            "-i",
+            str(src),
+            "-vn",
+            "-c:a",
+            "libmp3lame",
+            "-b:a",
+            bitrate,
+            "-ar",
+            sample_rate,
+            "-ac",
+            channels,
+            "-f",
+            "mp3",
+            "-v",
+            "error",
+            str(dest),
+        ],
         check=True,
     )
 

--- a/qua_jobs/download_audio.py
+++ b/qua_jobs/download_audio.py
@@ -333,8 +333,13 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("catalog", type=Path, help="Path to catalog.json (release-level or per-reciter)")
     p.add_argument("--reciter", help="Reciter slug (required unless the catalog has one reciter)")
     p.add_argument("--list", action="store_true", help="List reciters in the catalog and exit")
-    p.add_argument("--format", choices=("chapters", "original"), default="chapters",
-                   dest="fmt", help="Output layout (default: chapters = one file per surah)")
+    p.add_argument(
+        "--format",
+        choices=("chapters", "original"),
+        default="chapters",
+        dest="fmt",
+        help="Output layout (default: chapters = one file per surah)",
+    )
     p.add_argument("--out-dir", type=Path, help="Output directory (default: ./<slug>)")
     p.add_argument("--chapters", help="Comma-separated chapter subset (default: all)")
     p.add_argument("--bitrate", default="192k", help="CBR audio bitrate (default: 192k)")

--- a/qua_jobs/download_audio.py
+++ b/qua_jobs/download_audio.py
@@ -371,8 +371,13 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         dl_map = download_reciter(
-            reciter, out_dir, fmt=args.fmt, bitrate=args.bitrate,
-            sample_rate=args.sample_rate, channels=args.channels, only=only,
+            reciter,
+            out_dir,
+            fmt=args.fmt,
+            bitrate=args.bitrate,
+            sample_rate=args.sample_rate,
+            channels=args.channels,
+            only=only,
         )
     except MissingTool as exc:
         print(f"\nerror: {exc}", file=sys.stderr)

--- a/qua_jobs/download_audio.py
+++ b/qua_jobs/download_audio.py
@@ -176,12 +176,28 @@ def _download_source(url: str, *, bitrate: str, sample_rate: str, channels: str)
     src_dir = Path(tempfile.mkdtemp(prefix="qua_src_"))
     try:
         proc = subprocess.run(
-            [yt_dlp, "-f", _YTDLP_FORMAT, "--no-playlist",
-             "--extractor-args", _YTDLP_EXTRACTOR_ARGS,
-             "--retries", "5", "--fragment-retries", "5", "--retry-sleep", "5",
-             "--socket-timeout", "30",
-             "-o", str(src_dir / "src.%(ext)s"), "--force-overwrites", url],
-            capture_output=True, text=True,
+            [
+                yt_dlp,
+                "-f",
+                _YTDLP_FORMAT,
+                "--no-playlist",
+                "--extractor-args",
+                _YTDLP_EXTRACTOR_ARGS,
+                "--retries",
+                "5",
+                "--fragment-retries",
+                "5",
+                "--retry-sleep",
+                "5",
+                "--socket-timeout",
+                "30",
+                "-o",
+                str(src_dir / "src.%(ext)s"),
+                "--force-overwrites",
+                url,
+            ],
+            capture_output=True,
+            text=True,
         )
         srcs = [p for p in src_dir.iterdir() if p.name.startswith("src.")]
         if proc.returncode != 0 or not srcs:

--- a/qua_shared/schemas/wire/release.py
+++ b/qua_shared/schemas/wire/release.py
@@ -16,7 +16,7 @@ import re
 from enum import Enum
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, RootModel, model_validator
+from pydantic import BaseModel, ConfigDict, Field, RootModel, model_serializer, model_validator
 
 SCHEMA_VERSION = 1
 VERSE_KEY_RE = re.compile(r"^[1-9]\d{0,2}:[1-9]\d{0,2}$")
@@ -68,11 +68,30 @@ class ReleaseManifest(BaseModel):
 class ReleaseCatalogAudio(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    #: Per chapter, the NATIVE source URL the timestamps are relative to. For a
+    #: combined non-CDN source (one YouTube/Drive file serving several chapters)
+    #: this is the shared source URL — multiple chapters map to it, each at a
+    #: different ``chapter_offsets_ms``.
     chapter_urls: dict[str, str] = Field(default_factory=dict)
+    #: Per chapter, the ms offset of that chapter's start *inside* its source
+    #: URL. Present ONLY for non-CDN sources where the chapter doesn't begin at
+    #: byte 0 — combined files (one URL → many chapters) or a single file with a
+    #: trimmed lead-in. Absent/empty for CDN by-surah (each chapter is its own
+    #: file at offset 0). Map a release tier-file timestamp into the source file
+    #: with ``source_ms = chapter_offsets_ms.get(ch, 0) + tier_ms``. Omitted from
+    #: the serialized JSON when empty so CDN catalogs stay byte-stable.
+    chapter_offsets_ms: dict[str, int] = Field(default_factory=dict)
     sample_rate_hz: int | None = None
     channels: int | None = None
     bitrate_mode: str | None = None
     bitrate_kbps_nominal: int | None = None
+
+    @model_serializer(mode="wrap")
+    def _omit_empty_offsets(self, handler):
+        data = handler(self)
+        if not data.get("chapter_offsets_ms"):
+            data.pop("chapter_offsets_ms", None)
+        return data
 
 
 class ReleaseCoverage(BaseModel):

--- a/qua_shared/tests/test_cut_release_validate.py
+++ b/qua_shared/tests/test_cut_release_validate.py
@@ -195,9 +195,9 @@ def test_audio_urls_come_from_sidecar_chapters():
         },
     }
 
-    assert cut_release._audio_urls_from_manifest("example_reciter", sidecar) == {
-        "100": "https://cdn.example/100.mp3"
-    }
+    urls, offsets = cut_release._audio_sources_from_manifest("example_reciter", sidecar)
+    assert urls == {"100": "https://cdn.example/100.mp3"}
+    assert offsets == {}  # CDN by-surah: no offsets
 
 
 def test_audio_urls_tolerate_legacy_sidecar_metadata():
@@ -212,9 +212,56 @@ def test_audio_urls_tolerate_legacy_sidecar_metadata():
         },
     }
 
-    assert cut_release._audio_urls_from_manifest("legacy_reciter", sidecar) == {
-        "2": "https://cdn.example/2.mp3"
+    urls, offsets = cut_release._audio_sources_from_manifest("legacy_reciter", sidecar)
+    assert urls == {"2": "https://cdn.example/2.mp3"}
+    assert offsets == {}
+
+
+def test_combined_source_surfaces_native_url_and_offset():
+    # One Drive file serves chapters 1 + 2 (bucket path swapped into ``url``);
+    # the release must point at the native ``source_url`` and carry the offset of
+    # the chapter that starts partway into the file.
+    sidecar = {
+        "schema_version": 1,
+        "slug": "combined_reciter",
+        "_meta": {"checksum": "abc", "chapter_count": 2, "category": "by_surah"},
+        "chapters": {
+            "1": {
+                "url": "https://bucket/reciters/combined_reciter/audio/1.mp3",
+                "source_url": "https://drive.google.com/file/d/XYZ/view",
+            },
+            "2": {
+                "url": "https://bucket/reciters/combined_reciter/audio/2.mp3",
+                "source_url": "https://drive.google.com/file/d/XYZ/view",
+                "source_offset_ms": 215000,
+            },
+        },
     }
+
+    urls, offsets = cut_release._audio_sources_from_manifest("combined_reciter", sidecar)
+    assert urls == {
+        "1": "https://drive.google.com/file/d/XYZ/view",
+        "2": "https://drive.google.com/file/d/XYZ/view",
+    }
+    assert offsets == {"2": 215000}  # only the non-zero offset is emitted
+
+
+def test_single_file_offset_emitted_without_source_url():
+    # A unique-per-chapter source whose recitation starts after a lead-in: the
+    # URL is already native (no ``source_url``) but the offset must still ship.
+    sidecar = {
+        "_meta": {"checksum": "abc", "chapter_count": 1, "category": "by_surah"},
+        "chapters": {
+            "36": {
+                "url": "https://drive.google.com/file/d/ABC/view",
+                "source_offset_ms": 4200,
+            }
+        },
+    }
+
+    urls, offsets = cut_release._audio_sources_from_manifest("single_file_reciter", sidecar)
+    assert urls == {"36": "https://drive.google.com/file/d/ABC/view"}
+    assert offsets == {"36": 4200}
 
 
 def test_empty_audio_urls_are_fatal_for_catalog_build():

--- a/qua_shared/tests/test_download_audio.py
+++ b/qua_shared/tests/test_download_audio.py
@@ -1,0 +1,59 @@
+"""Unit tests for the release ``download_audio.py`` helper — pure parsing,
+chapter-window derivation, and the friendly missing-tool error path. The actual
+yt-dlp / ffmpeg downloads are not exercised here."""
+
+from __future__ import annotations
+
+import pytest
+
+from qua_jobs import download_audio as da
+
+
+def _reciter(slug: str, urls: dict, offsets: dict | None = None) -> dict:
+    audio: dict = {"chapter_urls": urls}
+    if offsets:
+        audio["chapter_offsets_ms"] = offsets
+    return {"slug": slug, "audio": audio}
+
+
+def test_reciters_in_handles_release_level_and_single():
+    rec = _reciter("a", {"1": "u"})
+    assert da._reciters_in({"recitations": [rec]}) == [rec]
+    assert da._reciters_in([rec]) == [rec]
+    assert da._reciters_in(rec) == [rec]  # bare per-reciter object
+
+
+def test_pick_reciter_requires_slug_when_ambiguous():
+    catalog = {"recitations": [_reciter("a", {"1": "u"}), _reciter("b", {"1": "u"})]}
+    with pytest.raises(ValueError, match="pass --reciter"):
+        da._pick_reciter(catalog, None)
+    assert da._pick_reciter(catalog, "b")["slug"] == "b"
+
+
+def test_pick_reciter_defaults_to_sole_entry():
+    catalog = {"recitations": [_reciter("only", {"1": "u"})]}
+    assert da._pick_reciter(catalog, None)["slug"] == "only"
+
+
+def test_needs_ytdlp_routes_by_url():
+    assert da._needs_ytdlp("https://www.youtube.com/watch?v=x") is True
+    assert da._needs_ytdlp("https://drive.google.com/file/d/x/view") is True
+    assert da._needs_ytdlp("https://cdn.example/001.mp3") is False
+    assert da._needs_ytdlp("https://cdn.example/001.mp3?token=abc") is False
+
+
+def test_chapter_windows_splits_combined_file_at_next_offset():
+    # Two chapters share one file at 130 ms and 67795 ms → ch1 ends where ch2
+    # begins; ch2 runs to end-of-file (None).
+    windows = da._chapter_windows({"1": 130, "2": 67795}, ["1", "2"])
+    assert windows == {"1": (130, 67795), "2": (67795, None)}
+
+
+def test_chapter_windows_single_file_trims_lead_in_to_eof():
+    windows = da._chapter_windows({"36": 4200}, ["36"])
+    assert windows == {"36": (4200, None)}
+
+
+def test_missing_tool_message_names_install_command():
+    with pytest.raises(da.MissingTool, match="pip install yt-dlp"):
+        da._require("yt-dlp-definitely-not-installed", "pip install yt-dlp")

--- a/qua_shared/tests/test_release_schemas.py
+++ b/qua_shared/tests/test_release_schemas.py
@@ -72,6 +72,37 @@ def test_release_catalog_requires_audio_url_map():
     assert catalog.recitations[0].audio.chapter_urls["100"].endswith("100.mp3")
 
 
+def test_chapter_offsets_omitted_from_json_when_empty():
+    # CDN by-surah: no offsets → the key must be ABSENT (not ``{}``) so existing
+    # catalogs stay byte-stable and their content_hash doesn't churn.
+    audio = ReleaseCatalogAudio(chapter_urls={"1": "https://cdn.example/1.mp3"})
+    dumped = audio.model_dump(mode="json", by_alias=True)
+    assert "chapter_offsets_ms" not in dumped
+
+
+def test_chapter_offsets_present_for_combined_source():
+    audio = ReleaseCatalogAudio(
+        chapter_urls={"1": "https://yt.example/v", "2": "https://yt.example/v"},
+        chapter_offsets_ms={"2": 215000},
+    )
+    dumped = audio.model_dump(mode="json", by_alias=True)
+    assert dumped["chapter_offsets_ms"] == {"2": 215000}
+    # Round-trips back through validation.
+    assert ReleaseCatalogAudio.model_validate(dumped).chapter_offsets_ms == {"2": 215000}
+
+
+def test_legacy_catalog_without_offsets_still_validates():
+    # An old release catalog.json (cut before the field existed) must load.
+    rec = ReleaseRecitationCatalog.model_validate(
+        {
+            "slug": "example_reciter",
+            "audio": {"chapter_urls": {"1": "https://cdn.example/1.mp3"}},
+            "coverage": {"surahs": 1, "ayahs": 3},
+        }
+    )
+    assert rec.audio.chapter_offsets_ms == {}
+
+
 def test_qpc_hafs_doc_validates_location_keys():
     doc = QpcHafsDoc.model_validate(
         {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -53,6 +53,7 @@ no-op-or-error by design. Idempotent `backfill_*`/`purge_*`/`convert_*` stay in
 - `backfill_*` (5), `convert_peaks_v2_to_v3`, `derive_pipeline_meta`, `rollback_peaks_slim` — re-runnable artefact backfills / conversions
 - `purge_pad_migration`, `purge_stale_wraps` — strip stale records from `detailed.json` / `edit_history`
 - `unignore_category` — bulk-revert `ignore_issue` ops (re-runnable data-fix)
+- `patch_release_audio_sources` — rewrite a shipped GH release's `catalog.json` to native source URLs + `chapter_offsets_ms` (re-runnable; no-op once the `cut_release` fix shipped)
 
 ### `diagnostics/`
 - `bench_storage.py` — benchmark backend read/write hot paths

--- a/scripts/backfills/patch_release_audio_sources.py
+++ b/scripts/backfills/patch_release_audio_sources.py
@@ -195,7 +195,9 @@ def main(argv: list[str] | None = None) -> int:
         return 3
     man_rt = _json_model_bytes(ReleaseManifest.model_validate(root_manifest))
     if man_rt != manifest_path.read_bytes():
-        print("error: manifest.json no-op round-trip not byte-identical — aborting", file=sys.stderr)
+        print(
+            "error: manifest.json no-op round-trip not byte-identical — aborting", file=sys.stderr
+        )
         return 3
 
     recitations: list[dict] = root_catalog["recitations"]

--- a/scripts/backfills/patch_release_audio_sources.py
+++ b/scripts/backfills/patch_release_audio_sources.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Patch a shipped GitHub release so playlist (YouTube/Drive) recitations carry
+their NATIVE source URL + per-chapter offset in ``catalog.json`` instead of the
+internal inspector bucket URL.
+
+Background. Before the ``cut_release`` fix, the GH release ``catalog.json`` was
+built from the audio manifest's ``chapters[*].url`` verbatim. For a combined
+non-CDN source (one YouTube/Drive file serving several chapters) the manifest
+stores a per-chapter *bucket* path in ``url`` and the real source in
+``source_url`` (+ ``source_offset_ms``), so the release leaked the bucket URL
+and dropped the offset. The HF dataset already resolved ``source_url`` per row;
+this brings already-shipped GH releases in line and is a no-op once the cut fix
+ships (re-running on a patched release finds nothing to change).
+
+What it does, per affected recitation (one whose bucket manifest carries a
+``source_url`` or a non-zero ``source_offset_ms`` on any chapter):
+
+1. rebuilds the in-zip ``catalog.json`` ``audio.chapter_urls`` from the bucket
+   manifest's native ``source_url``/``url`` and adds ``audio.chapter_offsets_ms``
+   (same resolution as ``cut_release._audio_sources_from_manifest``), keeping
+   every other field byte-for-byte;
+2. re-zips ``<slug>.zip`` (tier files untouched) and recomputes its sha256/bytes
+   + the manifest ``content_hash`` (``sha256(letter_tier.gz || catalog.json)``);
+3. rewrites the release-level ``catalog.json`` + ``manifest.json`` accordingly;
+4. re-uploads only the changed assets to the SAME release tag (``--apply``).
+
+Safety gates abort before any upload if the deterministic zip re-pack doesn't
+reproduce the shipped zip byte-for-byte, if a recomputed ``content_hash``
+doesn't match the shipped manifest, or if a no-change round-trip of
+``catalog.json`` / ``manifest.json`` isn't byte-identical — i.e. it only ever
+ships bytes it can prove it reproduced.
+
+The bucket manifests are read from the mount (``INSPECTOR_BUCKET_MOUNT`` or
+``--bucket-mount``); pass the PROD bucket mount since releases are cut from prod.
+
+Usage (dry-run prints the plan; ``--apply`` performs the upload)::
+
+    python scripts/backfills/patch_release_audio_sources.py --tag v2.0.0 \
+        --bucket-mount ~/qua-prod-bucket
+    python scripts/backfills/patch_release_audio_sources.py --tag v2.0.0 \
+        --bucket-mount ~/qua-prod-bucket --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from qua_jobs.cut_release import (  # noqa: E402
+    _audio_sources_from_manifest,
+    _json_model_bytes,
+    _pack_recitation_zip,
+    _sha256_hex,
+)
+from qua_shared.schemas import (  # noqa: E402
+    ReleaseCatalog,
+    ReleaseManifest,
+    ReleaseRecitationCatalog,
+)
+
+_TIER_FILES = (
+    "verse_timestamps.json.gz",
+    "word_timestamps.json.gz",
+    "letter_timestamps.json.gz",
+)
+
+
+def _gh(*args: str, repo: str, capture: bool = True) -> str:
+    """Run a ``gh`` subcommand, raising on failure."""
+    cmd = ["gh", *args, "--repo", repo]
+    proc = subprocess.run(cmd, capture_output=capture, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh {' '.join(args)} failed: {proc.stderr.strip()[:400]}")
+    return proc.stdout
+
+
+def _latest_tag(repo: str) -> str:
+    out = _gh("release", "view", "--json", "tagName", repo=repo)
+    return json.loads(out)["tagName"]
+
+
+def _download_asset(repo: str, tag: str, name: str, dest_dir: Path) -> Path:
+    dest = dest_dir / name
+    if dest.exists():
+        dest.unlink()
+    _gh("release", "download", tag, "--pattern", name, "--dir", str(dest_dir), repo=repo)
+    if not dest.exists():
+        raise RuntimeError(f"{name} not found in release {tag}")
+    return dest
+
+
+def _load_bucket_manifest(bucket_mount: Path, slug: str) -> dict | None:
+    path = bucket_mount / "catalog" / "audio_manifest" / f"{slug}.json"
+    if not path.exists():
+        return None
+    return json.loads(path.read_bytes())
+
+
+def _zip_members(zip_bytes: bytes) -> dict[str, bytes]:
+    out: dict[str, bytes] = {}
+    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+        for name in zf.namelist():
+            out[name] = zf.read(name)
+    return out
+
+
+def _fixed_audio_block(
+    existing_audio: dict, bucket_manifest: dict, slug: str
+) -> tuple[dict, int, int]:
+    """Return ``(new_audio, n_urls_changed, n_offsets_added)``.
+
+    Keys are constrained to the recitation's *shipped* ``chapter_urls`` so
+    coverage can't drift if the bucket manifest changed since the cut; each key's
+    URL/offset is re-resolved from the manifest (native source + offset), falling
+    back to the shipped URL when the manifest lacks the chapter.
+    """
+    native_urls, native_offsets = _audio_sources_from_manifest(slug, bucket_manifest)
+    old_urls: dict[str, str] = existing_audio.get("chapter_urls", {})
+    new_urls: dict[str, str] = {}
+    new_offsets: dict[str, int] = {}
+    urls_changed = 0
+    for key, old_url in old_urls.items():
+        new_url = native_urls.get(key, old_url)
+        new_urls[key] = new_url
+        if new_url != old_url:
+            urls_changed += 1
+        if key in native_offsets:
+            new_offsets[key] = native_offsets[key]
+    new_audio = dict(existing_audio)
+    new_audio["chapter_urls"] = new_urls
+    if new_offsets:
+        new_audio["chapter_offsets_ms"] = new_offsets
+    else:
+        new_audio.pop("chapter_offsets_ms", None)
+    return new_audio, urls_changed, len(new_offsets)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", help="Release tag (default: latest)")
+    parser.add_argument("--repo", default="Wider-Community/quranic-universal-audio")
+    parser.add_argument(
+        "--bucket-mount",
+        type=Path,
+        help="Bucket mount root (default: $INSPECTOR_BUCKET_MOUNT)",
+    )
+    parser.add_argument(
+        "--work-dir",
+        type=Path,
+        default=_REPO_ROOT / ".local" / "release-patch",
+        help="Where release assets are downloaded + rebuilt",
+    )
+    parser.add_argument("--apply", action="store_true", help="Upload the patched assets")
+    args = parser.parse_args(argv)
+
+    import os
+
+    bucket_mount = args.bucket_mount or (
+        Path(os.environ["INSPECTOR_BUCKET_MOUNT"])
+        if os.environ.get("INSPECTOR_BUCKET_MOUNT")
+        else None
+    )
+    if not bucket_mount or not bucket_mount.exists():
+        print(
+            f"error: bucket mount not found ({bucket_mount}); pass --bucket-mount",
+            file=sys.stderr,
+        )
+        return 2
+
+    repo = args.repo
+    tag = args.tag or _latest_tag(repo)
+    work = args.work_dir / tag
+    work.mkdir(parents=True, exist_ok=True)
+    print(f"== patching {repo} release {tag} (bucket: {bucket_mount}) ==")
+
+    catalog_path = _download_asset(repo, tag, "catalog.json", work)
+    manifest_path = _download_asset(repo, tag, "manifest.json", work)
+    root_catalog = json.loads(catalog_path.read_bytes())
+    root_manifest = json.loads(manifest_path.read_bytes())
+
+    # Gate 0: a no-change round-trip of both release-level files must be
+    # byte-identical, else our serialization would mutate untouched bytes.
+    cat_rt = _json_model_bytes(ReleaseCatalog.model_validate(root_catalog))
+    if cat_rt != catalog_path.read_bytes():
+        print("error: catalog.json no-op round-trip not byte-identical — aborting", file=sys.stderr)
+        return 3
+    man_rt = _json_model_bytes(ReleaseManifest.model_validate(root_manifest))
+    if man_rt != manifest_path.read_bytes():
+        print("error: manifest.json no-op round-trip not byte-identical — aborting", file=sys.stderr)
+        return 3
+
+    recitations: list[dict] = root_catalog["recitations"]
+    manifest_recs: dict = root_manifest["recitations"]
+
+    patched_slugs: list[str] = []
+    new_zip_bytes_by_slug: dict[str, bytes] = {}
+    summary: list[dict] = []
+
+    for rec in recitations:
+        slug = rec["slug"]
+        bm = _load_bucket_manifest(bucket_mount, slug)
+        if not bm:
+            continue
+        native_urls, native_offsets = _audio_sources_from_manifest(slug, bm)
+        # Affected iff the manifest expresses any provenance the shipped catalog
+        # can't have: a swapped bucket URL (source_url) or a non-zero offset.
+        chapters = bm.get("chapters") or {}
+        has_provenance = any(
+            (c.get("source_url") or (c.get("source_offset_ms") or 0) > 0)
+            for c in chapters.values()
+            if isinstance(c, dict)
+        )
+        if not has_provenance:
+            continue
+
+        zip_path = _download_asset(repo, tag, f"{slug}.zip", work)
+        zbytes = zip_path.read_bytes()
+        members = _zip_members(zbytes)
+
+        # Gate 1: deterministic re-pack of the UNCHANGED members must reproduce
+        # the shipped zip byte-for-byte (proves the pack path matches the cut).
+        if _pack_recitation_zip(slug, members) != zbytes:
+            print(f"error: {slug}: zip re-pack not byte-identical — aborting", file=sys.stderr)
+            return 4
+
+        letter_gz = members["letter_timestamps.json.gz"]
+        old_catalog_bytes = members["catalog.json"]
+
+        # Gate 2: our content_hash formula must reproduce the shipped manifest's.
+        old_hash = _sha256_hex(letter_gz + old_catalog_bytes)
+        shipped_hash = manifest_recs.get(slug, {}).get("content_hash")
+        if shipped_hash and old_hash != shipped_hash:
+            print(
+                f"error: {slug}: content_hash formula mismatch "
+                f"({old_hash[:12]} != {shipped_hash[:12]}) — aborting",
+                file=sys.stderr,
+            )
+            return 5
+
+        existing_catalog = json.loads(old_catalog_bytes)
+        new_audio, n_url, n_off = _fixed_audio_block(existing_catalog.get("audio", {}), bm, slug)
+        if n_url == 0 and "chapter_offsets_ms" not in new_audio:
+            continue  # already native — nothing to do (idempotent re-run)
+
+        new_catalog_dict = dict(existing_catalog)
+        new_catalog_dict["audio"] = new_audio
+        # Re-validate + canonical-serialize through the real model so the bytes
+        # match what a future fixed cut would emit.
+        new_catalog_bytes = _json_model_bytes(
+            ReleaseRecitationCatalog.model_validate(new_catalog_dict)
+        )
+
+        new_members = dict(members)
+        new_members["catalog.json"] = new_catalog_bytes
+        new_zip = _pack_recitation_zip(slug, new_members)
+        new_zip_bytes_by_slug[slug] = new_zip
+        new_hash = _sha256_hex(letter_gz + new_catalog_bytes)
+
+        # Update the release-level structures in place.
+        rec["audio"] = json.loads(new_catalog_bytes)["audio"]
+        mrec = manifest_recs[slug]
+        mrec["sha256"] = _sha256_hex(new_zip)
+        mrec["bytes"] = len(new_zip)
+        mrec["content_hash"] = new_hash
+
+        patched_slugs.append(slug)
+        summary.append(
+            {
+                "slug": slug,
+                "urls_fixed": n_url,
+                "offsets_added": n_off,
+                "content_hash": f"{old_hash[:10]} -> {new_hash[:10]}",
+            }
+        )
+
+    if not patched_slugs:
+        print("no affected recitations — release already carries native sources.")
+        return 0
+
+    print(f"\n{len(patched_slugs)} recitation(s) to patch:")
+    for s in summary:
+        print(
+            f"  {s['slug']:42s} urls_fixed={s['urls_fixed']:<4d} "
+            f"offsets_added={s['offsets_added']:<4d} content_hash {s['content_hash']}"
+        )
+
+    # Re-serialize the release-level files (only patched entries changed; the
+    # rest are byte-identical, per Gate 0).
+    new_catalog_bytes = _json_model_bytes(ReleaseCatalog.model_validate(root_catalog))
+    new_manifest_bytes = _json_model_bytes(ReleaseManifest.model_validate(root_manifest))
+    (work / "catalog.json").write_bytes(new_catalog_bytes)
+    (work / "manifest.json").write_bytes(new_manifest_bytes)
+    for slug, zb in new_zip_bytes_by_slug.items():
+        (work / f"{slug}.zip").write_bytes(zb)
+
+    if not args.apply:
+        print(f"\n[dry-run] rebuilt assets written to {work}. Re-run with --apply to upload.")
+        return 0
+
+    print(f"\nuploading {len(patched_slugs) + 2} asset(s) to {tag} ...")
+    upload = [work / "manifest.json", work / "catalog.json"]
+    upload += [work / f"{slug}.zip" for slug in patched_slugs]
+    for path in upload:
+        print(f"  upload {path.name} ...")
+        _gh("release", "upload", tag, str(path), "--clobber", repo=repo, capture=True)
+    print("done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

For playlist sources (YouTube / Google Drive), the GH release `catalog.json` was giving the **internal inspector bucket URL** as the chapter audio source instead of the **native source**. It was built from the audio manifest's `chapters[*].url` verbatim — but for a combined-file intake (one source file serving several chapters) the manifest deliberately stores a per-chapter *bucket* path in `url` and the real source in `source_url` (+ `source_offset_ms`). So the release:

1. **leaked bucket URLs** for combined chapters, and
2. **silently dropped the offset** even for chapters whose URL was already native (a single file with a trimmed lead-in) — so a consumer aligning release timestamps against the native file would be off by the lead-in.

The HF dataset already resolved `source_url`/`source_offset_ms` per row; the GH adapter didn't.

## Fix (so future releases are correct)

- **Schema** (`ReleaseCatalogAudio`): one new optional `chapter_offsets_ms` map — `chapter -> ms offset within its (shared) source file`. A `model_serializer` **omits it when empty**, so CDN by-surah catalogs stay byte-stable and their `content_hash` doesn't churn. Non-disruptive: existing CDN releases/consumers are untouched; it only appears for non-CDN combined sources.
- **`cut_release`**: `_audio_sources_from_manifest` now surfaces the native `source_url` (falling back to `url`) and collects `source_offset_ms` into `chapter_offsets_ms`, mirroring `publish_hf`. Mapping: `source_ms = chapter_offsets_ms.get(ch, 0) + tier_ms`.

## Consumer helper

- **`download_audio.py`** shipped as a release asset (staged + uploaded by the cut). Reads `catalog.json` and fetches a reciter's source audio re-encoded to the alignment profile (**192 kbps CBR / 44.1 kHz / mono**, configurable via `--bitrate/--sample-rate/--channels`). Two layouts:
  - `--format chapters` (default): one offset-0 file per surah (`001.mp3 … 114.mp3`) — splits a combined file at the chapter offsets so release timestamps apply directly.
  - `--format original`: the source files as published, plus a `download_map.json` of chapter→file+offset.
  - Uses `yt-dlp` + `ffmpeg` for YouTube/Drive, **fails loud with install hints** when a tool is missing; needs neither for direct CDN MP3s.

## Backfill — the already-shipped release

`scripts/backfills/patch_release_audio_sources.py` rewrites a shipped release's `catalog.json` in place (re-runnable; no-op once this fix is live). **Applied to `v2.0.0`** — 4 reciters patched (zero bucket-URL leaks remain), `download_audio.py` uploaded:

| slug | urls fixed | offsets added |
|---|---|---|
| `abdul_hamid_ghraio_2026_yt` | 48 | 48 |
| `abdullah_al_buaijan_2025_yt` | 2 | 1 |
| `ibrahim_al_akhdar_drive` | 71 | 71 |
| `mohammed_ayyub_drive` | 71 | 110 |

Safety gates abort before any upload unless the deterministic zip re-pack reproduces the shipped zip byte-for-byte and the recomputed `content_hash` matches the shipped manifest. The patched manifest `content_hash` change makes `check_updates.py` flag these 4 so consumers re-pull the corrected zips.

### Verified end-to-end against the live release
- Live `v2.0.0` catalog: **0** remaining bucket-URL leaks; offsets present on all 4.
- Live patched zip: sha256 + bytes + recomputed `content_hash` all match `manifest.json`.
- Live download test (Drive combined file → split): Al-Baqarah's last verse ends at 9375.7s, the split file is 9376.2s — offset + split are exact.

## Tests
- `qua_shared` (165) + release routes (18) + job staging (4) green.
- New: `test_download_audio.py`; offset/native-URL cases in `test_cut_release_validate.py`; empty-omit serialization in `test_release_schemas.py`.

## Notes
- FE types unchanged — `ReleaseCatalogAudio` is a release artifact, not FE-facing (codegen check passes).
- The prod DB release ledger is intentionally untouched; the next fixed cut reconciles the 4 as `refresh`.