### PR TITLE
fix(segs-fe): autoplay — sync segCurrentIdx on gap-skip so highlight advances

### DIFF
--- a/inspector/frontend/src/tabs/segments/utils/playback/playback.ts
+++ b/inspector/frontend/src/tabs/segments/utils/playback/playback.ts
@@ -167,15 +167,20 @@ function _maybeSkipDeletedGap(timeMs: number): boolean {
         // the chapter's trailing audio.
         segPort.pause();
         setPlayingSegment(null);
+        segCurrentIdx.set(-1);
         _drawLoop.stop();
         return true;
     }
 
-    // Jump the active pair (drives class:playing + the playhead row) and seek
-    // to the surviving segment. `segCurrentIdx`, warmup, and on-demand peaks are
-    // reconciled by `onSegTimeUpdate`'s next tick once the playhead lands inside
-    // `next` and its crossing block fires.
+    // Jump the active pair (drives class:playing + the playhead row) and seek to
+    // the surviving segment. `segCurrentIdx` MUST advance in lockstep: this same
+    // rAF loop calls `updateSegHighlight` right after us, and it forces
+    // `playingSegmentIndex` back onto `segCurrentIdx` every frame. Leaving
+    // `segCurrentIdx` on the segment we just left lets that bridge snap the
+    // active pair backwards until `onSegTimeUpdate`'s slower tick catches up —
+    // the highlight stalls/repeats on the previous segment across the gap.
     setPlayingSegment({ chapter: next.chapter ?? active.chapter, index: next.index });
+    segCurrentIdx.set(next.index);
     segPort.seek(next.time_start);
     return true;
 }


### PR DESCRIPTION
## Problem

In the Segments tab, **main-list chapter-continuous autoplay** (autoplay ON) sometimes stalls/repeats on the same segment instead of advancing to the next one. It's non-deterministic ("sometimes fine") and affects the same (verse-end / pause-followed) segments. It **never** reproduces inside a validation accordion.

## Root cause

The current segment is tracked in two stores updated within one rAF frame by `_drawLoop`:
- `playingSegmentIndex` — active `{chapter, index}` pair (drives `class:playing` + playhead row)
- `segCurrentIdx` — plain index

Each frame runs `_maybeSkipDeletedGap(t)` then `updateSegHighlight()`:
- `_maybeSkipDeletedGap` (fires whenever the playhead enters a region covered by no displayed segment — i.e. every natural inter-segment pause, not just deleted gaps) advanced **`playingSegmentIndex`** to the next segment and seeked, but left **`segCurrentIdx`** on the segment just left.
- `updateSegHighlight` then forces `playingSegmentIndex` back onto `segCurrentIdx` every frame, reverting the active pair backwards.

The prior code relied on `onSegTimeUpdate`'s *next* tick to reconcile `segCurrentIdx`, but that fires on the slow `timeupdate` cadence (~4 Hz) vs the 60 Hz rAF — so `updateSegHighlight` wins the race and snaps the highlight back. Whether a `timeupdate` landed in the (short) gap first is what made it non-deterministic.

**Why the accordion is immune:** `_maybeSkipDeletedGap` bails for accordion-origin plays (`active.origin === 'accordion'`), and accordion advance is explicit (`accordionStep` → `playFromSegment`). The inconsistent path is never taken there.

## Fix

Advance `segCurrentIdx` in lockstep when the gap-skip moves (or stops) the active pair, so `updateSegHighlight` can't revert it: `segCurrentIdx.set(next.index)` on advance, `segCurrentIdx.set(-1)` on the end-of-chapter stop. Highlight/state bookkeeping only — audio seek behavior is unchanged.

## Testing
- `tsc --noEmit` ✅
- `eslint` ✅
- vitest playback/audio suites: 144 passed ✅

## Note (not changed)
Because segments aren't truly contiguous, autoplay already seeks over natural pauses today; this PR only removes the visible repeat/stall. Making autoplay *play through* natural pauses would be a separate change (distinguishing a deleted-segment gap from a natural pause).

https://claude.ai/code/session_015bMHcucBQ8DpU2Dw13Fy8k

---
_Generated by [Claude Code](https://claude.ai/code/session_015bMHcucBQ8DpU2Dw13Fy8k)_