### PR TITLE
fix(ts): random-ayah shuffle leaks the next verse on short ayahs

### DIFF
--- a/inspector/frontend/src/tabs/timestamps/TimestampsTab.svelte
+++ b/inspector/frontend/src/tabs/timestamps/TimestampsTab.svelte
@@ -85,6 +85,7 @@
         selectedVerse,
         type TsLoadedVerse,
     } from './stores/verse';
+    import { resolveShuffleTick, shouldFireShuffle, verseAt } from './utils/shuffle-tick';
     import { setupZoomLifecycle } from './utils/zoom';
 
     // ---- Local display constants ----
@@ -376,14 +377,11 @@
     /** Focus the verse containing `ms` (chapter-absolute), else the nearest
      *  preceding one. No-op if the focus is unchanged. */
     function focusAt(ms: number): void {
-        if (chapterVerses.length === 0) return;
-        let hit: ChapVerse | null = null;
-        for (const v of chapterVerses) {
-            if (ms >= v.startMs && ms < v.endMs) { hit = v; break; }
-            if (v.startMs <= ms) hit = v; // nearest preceding
+        const ref = verseAt(chapterVerses, ms);
+        if (ref && ref !== focusRef) {
+            const v = chapterVerses.find((x) => x.ref === ref);
+            if (v) setFocus(v);
         }
-        const v = hit ?? chapterVerses[0]!;
-        if (v.ref !== focusRef) setFocus(v);
     }
 
     // ---------------------------------------------------------------------
@@ -428,32 +426,54 @@
             return;
         }
 
-        focusAt(ms);
-        // rAF gives tight (~16 ms) boundary timing while the tab is active; the
-        // onTimeUpdate/onEnded media-clock backstop (onMount) catches the boundary
-        // when rAF is throttled (backgrounded tab / GC / heavy repaint), where it
-        // would otherwise overshoot by 1-3 words. The once-per-verse guard dedupes
-        // whichever fires first.
-        maybeFireShuffle(ms);
+        // Resolve the ayah-end shuffle boundary BEFORE advancing focus. Advancing
+        // focus first (the old order) would flip the verse the boundary is measured
+        // against to the NEXT ayah the instant the playhead crosses a contiguous
+        // seam — so a frame that overshoots the seam (heavy repaint right after a
+        // jump starves rAF, most visible when the just-loaded ayah is short) re-bases
+        // onto the next ayah and leaks it in full. Deciding fire-vs-focus together,
+        // against the auditioned ayah's captured end, bounds the leak to one frame.
+        const fv = get(loadedVerse);
+        const outcome = resolveShuffleTick({
+            verses: chapterVerses,
+            ms,
+            armed: getActiveTab() === TAB_NAMES.TIMESTAMPS && !get(loopTarget) && get(shuffleAyah),
+            focusEndMs: fv ? fv.tsSegEnd * 1000 : null,
+            guardMs: SHUFFLE_END_GUARD_MS,
+            firedForCurrentFocus: shuffleFiredForRef === focusRef,
+        });
+        if (outcome.kind === 'fire') {
+            shuffleFiredForRef = focusRef;
+            void shuffleJump(); // sets the new focus itself; hold focus this frame
+        } else if (outcome.ref && outcome.ref !== focusRef) {
+            const v = chapterVerses.find((x) => x.ref === outcome.ref);
+            if (v) setFocus(v);
+        }
         refreshDisplays();
     }
 
-    // Ayah-end shuffle boundary: jump to a random target when the playhead reaches
-    // the focus verse's end (once per verse). Called from both the rAF tick and the
-    // onTimeUpdate/onEnded media-clock backstop; reads the focus verse fresh so the
-    // boundary and the dedupe key never disagree. Gated to the active Timestamps tab
-    // so the shared dashPort backstop can't hijack Dashboard playback (its own
-    // gapless advance owns dashPort.onEnded when that tab is active).
-    function maybeFireShuffle(ms: number): void {
-        if (getActiveTab() !== TAB_NAMES.TIMESTAMPS) return;
-        if (get(loopTarget) || !get(shuffleAyah)) return;
+    // Media-clock backstop for the ayah-end shuffle: fire the jump when the playhead
+    // reaches the auditioned ayah's end. Driven off onTimeUpdate/onEnded so the
+    // boundary is still caught when rAF is throttled (backgrounded tab) — where the
+    // tick (and so focus) isn't advancing, so the focus verse IS the auditioned one.
+    // Gated to the active Timestamps tab so the shared dashPort backstop can't hijack
+    // Dashboard playback (its own gapless advance owns dashPort.onEnded when active).
+    function maybeFireShuffle(ms: number): boolean {
+        if (getActiveTab() !== TAB_NAMES.TIMESTAMPS) return false;
         const fv = get(loadedVerse);
-        if (!fv) return;
-        const endMs = fv.tsSegEnd * 1000;
-        if (ms >= endMs - SHUFFLE_END_GUARD_MS && shuffleFiredForRef !== focusRef) {
+        const fire = shouldFireShuffle({
+            armed: !get(loopTarget) && get(shuffleAyah),
+            ms,
+            focusEndMs: fv ? fv.tsSegEnd * 1000 : null,
+            guardMs: SHUFFLE_END_GUARD_MS,
+            firedForCurrentFocus: shuffleFiredForRef === focusRef,
+        });
+        if (fire) {
             shuffleFiredForRef = focusRef;
             void shuffleJump();
+            return true;
         }
+        return false;
     }
 
     function refreshDisplays(): void {

--- a/inspector/frontend/src/tabs/timestamps/TimestampsTab.svelte
+++ b/inspector/frontend/src/tabs/timestamps/TimestampsTab.svelte
@@ -384,6 +384,20 @@
         }
     }
 
+    /** True while a cross-source jump is mid-swap: the shared player already points
+     *  at (and may already be playing) the new chapter, but `chapterVerses` /
+     *  `focusRef` / `loadedVerse` still describe the previous chapter until
+     *  syncChapter finishes loading and sets `loadedChapterKey`. `loadedChapterKey`
+     *  trails `playerContext` across the whole window (incl. before `tsLoading`
+     *  flips at line ~289), so it — not `tsLoading` — is the reliable guard. tick()
+     *  and the media-clock backstop both no-op during this window so the new
+     *  playhead time isn't read against stale verses (wrong-verse focus +
+     *  double-fire). */
+    function chapterSwapInFlight(): boolean {
+        const ctx = get(playerContext);
+        return `${ctx.delivery?.slug ?? ''}:${ctx.surahNum ?? 0}` !== loadedChapterKey;
+    }
+
     // ---------------------------------------------------------------------
     // Per-frame tick (focus + highlights + waveform cursor + loop + shuffle)
     // ---------------------------------------------------------------------
@@ -437,11 +451,15 @@
         const outcome = resolveShuffleTick({
             verses: chapterVerses,
             ms,
+            swapInFlight: chapterSwapInFlight(),
             armed: getActiveTab() === TAB_NAMES.TIMESTAMPS && !get(loopTarget) && get(shuffleAyah),
             focusEndMs: fv ? fv.tsSegEnd * 1000 : null,
             guardMs: SHUFFLE_END_GUARD_MS,
             firedForCurrentFocus: shuffleFiredForRef === focusRef,
         });
+        // Mid-swap: freeze focus + display (no refresh) so the new playhead time
+        // isn't drawn against the old chapter's verse; syncChapter resumes us.
+        if (outcome.kind === 'idle') return;
         if (outcome.kind === 'fire') {
             shuffleFiredForRef = focusRef;
             void shuffleJump(); // sets the new focus itself; hold focus this frame
@@ -460,6 +478,10 @@
     // Dashboard playback (its own gapless advance owns dashPort.onEnded when active).
     function maybeFireShuffle(ms: number): boolean {
         if (getActiveTab() !== TAB_NAMES.TIMESTAMPS) return false;
+        // Mid-swap the timeupdate clock is the NEW chapter's but loadedVerse is the
+        // OLD one — measuring against it would fire against the wrong ayah. tick()
+        // also freezes focus here, so this is belt-and-braces, not the sole guard.
+        if (chapterSwapInFlight()) return false;
         const fv = get(loadedVerse);
         const fire = shouldFireShuffle({
             armed: !get(loopTarget) && get(shuffleAyah),

--- a/inspector/frontend/src/tabs/timestamps/components/UnifiedDisplay.svelte
+++ b/inspector/frontend/src/tabs/timestamps/components/UnifiedDisplay.svelte
@@ -28,7 +28,7 @@
         verseTranslations,
     } from '../stores/display';
     import type { TsLoopTarget } from '../stores/playback';
-    import { autoMode, loopTarget } from '../stores/playback';
+    import { loopTarget } from '../stores/playback';
     import { loadedVerse } from '../stores/verse';
     import { TS_CLICK_DELAY_MS } from '../utils/constants';
     import WordTranslation from './WordTranslation.svelte';
@@ -476,8 +476,7 @@
 
     /**
      * Toggle loop on the given token. If it's already the looped target,
-     * exit loop mode; otherwise engage loop + seek to its start. Also
-     * clears `autoMode` (loop + auto-advance are mutually exclusive).
+     * exit loop mode; otherwise engage loop + seek to its start.
      */
     function toggleLoopOn(target: TsLoopTarget): void {
         const lv = get(loadedVerse);
@@ -492,7 +491,6 @@
             return;
         }
         loopTarget.set(target);
-        autoMode.set(null);
         seekToTime(target.startSec + lv.tsSegOffset);
         // Zoom/pan is handled by the centralized `loopTarget` subscription in
         // `utils/zoom.ts::setupZoomLifecycle` — no per-callsite hook needed.

--- a/inspector/frontend/src/tabs/timestamps/stores/playback.ts
+++ b/inspector/frontend/src/tabs/timestamps/stores/playback.ts
@@ -1,55 +1,12 @@
 /**
- * Timestamps tab — playback control state.
- */
-
-import { writable } from 'svelte/store';
-
-import { AudioPort } from '../../../lib/playback/audio-port';
-
-/** Auto-advance mode — null = off, 'next' = advance to next verse on end,
- *  'random-any' = load random verse from any reciter on end,
- *  'random-current' = load random verse from the currently-selected reciter on end. */
-export type TsAutoMode = 'next' | 'random-any' | 'random-current' | null;
-
-/** Current auto-advance mode. */
-export const autoMode = writable<TsAutoMode>(null);
-
-/** Guard against re-entry from the timeupdate handler when the end is crossed. */
-export const autoAdvancing = writable<boolean>(false);
-
-/** Audio element current time (seconds, absolute). Updated per animation frame. */
-export const currentTime = writable<number>(0);
-
-/** The <audio> element driving timestamps-tab playback.
+ * Timestamps tab — region-loop re-export shim.
  *
- *  @deprecated Use `tsPort` instead. The audio element is now wrapped by
- *  the port; this export is retained transitionally. The Timestamps tab
- *  is currently CBR-only — when it gains VBR support, the port already
- *  carries the offset translation needed for clip-relative `currentTime`. */
-export const tsAudioElement = writable<HTMLAudioElement | null>(null);
-
-/** Single AudioPort for the Timestamps tab. Every consumer (waveform
- *  clicks, keyboard nudges, karaoke tick reads) imports this port and
- *  reads file-absolute milliseconds.
- *
- *  Coordinate space: file-absolute ms — always. The Timestamps tab is
- *  CBR-only today, so file-absolute equals `audio.currentTime * 1000`,
- *  but routing reads through the port keeps the codebase ready for VBR
- *  routing without a second-pass rewrite. */
-export const tsPort: AudioPort = new AudioPort();
-
-/** True when `tsPort` has an `<audio>` element bound. Mirrors the
- *  segments-tab `segPortReady` shape. */
-export const tsPortReady = writable<boolean>(false);
-
-/** Chapters of the selected timestamp reciter whose audio is known VBR. */
-export const tsVbrChapters = writable<Set<number>>(new Set());
-
-/**
- * Region loop state now lives in `lib/playback/loop` so the shared footer +
- * filmstrip (lib components) can also clear it. Re-exported here so existing
- * `../stores/playback` imports of `loopTarget` / `TsLoopTarget` keep working.
+ * Live playback state for the tab flows through the shared `dashPort`; the only
+ * tab-local playback state is the region loop, which lives in `lib/playback/loop`
+ * so the shared footer + filmstrip (lib components) can also clear it. It's
+ * re-exported here so the tab's `../stores/playback` imports resolve.
  * `exitLoop()` force-drops loop mode on any deliberate navigation.
  */
+
 export { exitLoop, loopTarget } from '../../../lib/playback/loop';
 export type { TsLoopTarget } from '../../../lib/playback/loop';

--- a/inspector/frontend/src/tabs/timestamps/utils/__tests__/shuffle-tick.test.ts
+++ b/inspector/frontend/src/tabs/timestamps/utils/__tests__/shuffle-tick.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    resolveShuffleTick,
+    shouldFireShuffle,
+    verseAt,
+    type ShuffleTickVerse,
+} from '../shuffle-tick';
+
+// Three ayahs recited continuously → contiguous (each end == next start), so
+// the playhead crosses a seam with no gap. This is the shape that triggered the
+// short-verse leak.
+const CONTIGUOUS: ShuffleTickVerse[] = [
+    { ref: '2:1', startMs: 0, endMs: 1000 },
+    { ref: '2:2', startMs: 1000, endMs: 2000 },
+    { ref: '2:3', startMs: 2000, endMs: 3000 },
+];
+
+const GUARD = 40;
+
+describe('resolveShuffleTick', () => {
+    it('fires against the auditioned ayah even when a skipped frame overshoots past its end', () => {
+        // Auditioning 2:1 (ends at 1000). A starved rAF frame lands the playhead at
+        // 1400 — already inside the contiguous next ayah. The fire must still resolve
+        // against 2:1's end, NOT re-base onto 2:2 (which would leak 2:2 in full).
+        const outcome = resolveShuffleTick({
+            verses: CONTIGUOUS,
+            ms: 1400,
+            armed: true,
+            focusEndMs: 1000,
+            guardMs: GUARD,
+            firedForCurrentFocus: false,
+        });
+
+        expect(outcome).toEqual({ kind: 'fire' });
+    });
+
+    it('fires within the early guard window before the exact ayah end', () => {
+        const outcome = resolveShuffleTick({
+            verses: CONTIGUOUS,
+            ms: 970,
+            armed: true,
+            focusEndMs: 1000,
+            guardMs: GUARD,
+            firedForCurrentFocus: false,
+        });
+
+        expect(outcome).toEqual({ kind: 'fire' });
+    });
+
+    it('advances focus to the containing ayah, without firing, before the guard window', () => {
+        const outcome = resolveShuffleTick({
+            verses: CONTIGUOUS,
+            ms: 950,
+            armed: true,
+            focusEndMs: 1000,
+            guardMs: GUARD,
+            firedForCurrentFocus: false,
+        });
+
+        expect(outcome).toEqual({ kind: 'focus', ref: '2:1' });
+    });
+
+    it('does not re-fire for an ayah it already fired for; advances focus instead', () => {
+        const outcome = resolveShuffleTick({
+            verses: CONTIGUOUS,
+            ms: 1400,
+            armed: true,
+            focusEndMs: 1000,
+            guardMs: GUARD,
+            firedForCurrentFocus: true,
+        });
+
+        expect(outcome).toEqual({ kind: 'focus', ref: '2:2' });
+    });
+
+    it('does not fire when shuffle is disarmed; tracks focus normally', () => {
+        const outcome = resolveShuffleTick({
+            verses: CONTIGUOUS,
+            ms: 1400,
+            armed: false,
+            focusEndMs: 1000,
+            guardMs: GUARD,
+            firedForCurrentFocus: false,
+        });
+
+        expect(outcome).toEqual({ kind: 'focus', ref: '2:2' });
+    });
+});
+
+describe('shouldFireShuffle', () => {
+    it('treats the guard as a lower bound — an arbitrarily large overshoot still fires', () => {
+        expect(
+            shouldFireShuffle({
+                armed: true,
+                ms: 9999,
+                focusEndMs: 1000,
+                guardMs: GUARD,
+                firedForCurrentFocus: false,
+            }),
+        ).toBe(true);
+    });
+
+    it('does not fire when no verse is loaded (null end)', () => {
+        expect(
+            shouldFireShuffle({
+                armed: true,
+                ms: 9999,
+                focusEndMs: null,
+                guardMs: GUARD,
+                firedForCurrentFocus: false,
+            }),
+        ).toBe(false);
+    });
+});
+
+describe('verseAt', () => {
+    it('returns the ayah whose span contains the playhead', () => {
+        expect(verseAt(CONTIGUOUS, 1500)).toBe('2:2');
+    });
+
+    it('returns the nearest preceding ayah when the playhead sits in a gap', () => {
+        const gapped: ShuffleTickVerse[] = [
+            { ref: '7:1', startMs: 0, endMs: 1000 },
+            { ref: '7:2', startMs: 2000, endMs: 3000 },
+        ];
+
+        expect(verseAt(gapped, 1500)).toBe('7:1');
+    });
+
+    it('returns the first ayah when the playhead precedes all spans', () => {
+        const offset: ShuffleTickVerse[] = [
+            { ref: '9:1', startMs: 100, endMs: 1000 },
+            { ref: '9:2', startMs: 1000, endMs: 2000 },
+        ];
+
+        expect(verseAt(offset, 50)).toBe('9:1');
+    });
+
+    it('returns null when there are no verses', () => {
+        expect(verseAt([], 100)).toBeNull();
+    });
+});

--- a/inspector/frontend/src/tabs/timestamps/utils/__tests__/shuffle-tick.test.ts
+++ b/inspector/frontend/src/tabs/timestamps/utils/__tests__/shuffle-tick.test.ts
@@ -25,6 +25,7 @@ describe('resolveShuffleTick', () => {
         // against 2:1's end, NOT re-base onto 2:2 (which would leak 2:2 in full).
         const outcome = resolveShuffleTick({
             verses: CONTIGUOUS,
+            swapInFlight: false,
             ms: 1400,
             armed: true,
             focusEndMs: 1000,
@@ -38,6 +39,7 @@ describe('resolveShuffleTick', () => {
     it('fires within the early guard window before the exact ayah end', () => {
         const outcome = resolveShuffleTick({
             verses: CONTIGUOUS,
+            swapInFlight: false,
             ms: 970,
             armed: true,
             focusEndMs: 1000,
@@ -51,6 +53,7 @@ describe('resolveShuffleTick', () => {
     it('advances focus to the containing ayah, without firing, before the guard window', () => {
         const outcome = resolveShuffleTick({
             verses: CONTIGUOUS,
+            swapInFlight: false,
             ms: 950,
             armed: true,
             focusEndMs: 1000,
@@ -64,6 +67,7 @@ describe('resolveShuffleTick', () => {
     it('does not re-fire for an ayah it already fired for; advances focus instead', () => {
         const outcome = resolveShuffleTick({
             verses: CONTIGUOUS,
+            swapInFlight: false,
             ms: 1400,
             armed: true,
             focusEndMs: 1000,
@@ -77,6 +81,7 @@ describe('resolveShuffleTick', () => {
     it('does not fire when shuffle is disarmed; tracks focus normally', () => {
         const outcome = resolveShuffleTick({
             verses: CONTIGUOUS,
+            swapInFlight: false,
             ms: 1400,
             armed: false,
             focusEndMs: 1000,
@@ -85,6 +90,58 @@ describe('resolveShuffleTick', () => {
         });
 
         expect(outcome).toEqual({ kind: 'focus', ref: '2:2' });
+    });
+});
+
+describe('resolveShuffleTick — cross-source chapter swap window', () => {
+    // After a cross-source jump, the shared player points at the NEW chapter (so
+    // the playhead time is the new chapter's) while `verses` still describes the
+    // OLD chapter, until its data loads. Every frame in that window must hold:
+    // firing again or focusing an old-chapter verse is the double-fire / wrong-
+    // verse-flash bug.
+    it('holds (idle) when a frame would otherwise fire, even with the once-per-ayah guard disarmed', () => {
+        // Worst case: the guard is already disarmed (firedForCurrentFocus false) and
+        // the new playhead (1400) has overshot the OLD 2:1 end (1000) — exactly the
+        // condition that produced the second mid-recitation jump.
+        const outcome = resolveShuffleTick({
+            verses: CONTIGUOUS, // OLD chapter
+            swapInFlight: true,
+            ms: 1400, // NEW-chapter time
+            armed: true,
+            focusEndMs: 1000,
+            guardMs: GUARD,
+            firedForCurrentFocus: false,
+        });
+
+        expect(outcome).toEqual({ kind: 'idle' });
+    });
+
+    it('holds (idle) instead of focusing an old-chapter verse mid-swap', () => {
+        const outcome = resolveShuffleTick({
+            verses: CONTIGUOUS,
+            swapInFlight: true,
+            ms: 500, // would normally focus 2:1
+            armed: false,
+            focusEndMs: 1000,
+            guardMs: GUARD,
+            firedForCurrentFocus: true,
+        });
+
+        expect(outcome).toEqual({ kind: 'idle' });
+    });
+
+    it('resumes normal firing once the swap completes', () => {
+        const outcome = resolveShuffleTick({
+            verses: CONTIGUOUS,
+            swapInFlight: false,
+            ms: 1400,
+            armed: true,
+            focusEndMs: 1000,
+            guardMs: GUARD,
+            firedForCurrentFocus: false,
+        });
+
+        expect(outcome).toEqual({ kind: 'fire' });
     });
 });
 

--- a/inspector/frontend/src/tabs/timestamps/utils/shuffle-tick.ts
+++ b/inspector/frontend/src/tabs/timestamps/utils/shuffle-tick.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure per-frame decision for the Timestamps tab's auto-random ("shuffle")
+ * boundary, split out of `TimestampsTab`'s rAF tick so the contiguous-seam
+ * overshoot race is unit-testable without rAF / audio / store plumbing.
+ *
+ * Ayahs recited continuously are contiguous (verse N's end == verse N+1's
+ * start), so the playhead crosses a seam with no gap. Each frame the tick must
+ * decide whether to FIRE the shuffle jump (the auditioned ayah just ended)
+ * BEFORE it advances the visual focus — otherwise a frame that overshoots the
+ * seam (heavy repaint right after a jump starves rAF, most visible when the
+ * just-loaded ayah is short) would re-base the boundary onto the NEXT ayah and
+ * leak it in full. Resolving the fire decision first, against the auditioned
+ * ayah's captured end, bounds the leak to a single frame.
+ */
+
+export interface ShuffleTickVerse {
+    ref: string;
+    startMs: number;
+    endMs: number;
+}
+
+export type ShuffleTickOutcome =
+    | { kind: 'fire' }
+    | { kind: 'focus'; ref: string | null };
+
+export interface ShuffleFireArgs {
+    /** Shuffle is engaged on the active tab and not overridden by a region loop. */
+    armed: boolean;
+    /** Playhead, chapter-absolute ms. */
+    ms: number;
+    /** End of the ayah currently being auditioned (chapter-absolute ms), or null
+     *  when no verse is loaded. */
+    focusEndMs: number | null;
+    /** Fire this many ms before the exact end so the jump lands without a beat of
+     *  the next ayah leaking in. */
+    guardMs: number;
+    /** True once the jump has already fired for the ayah in focus (once-per-ayah
+     *  guard). */
+    firedForCurrentFocus: boolean;
+}
+
+/** The ayah-end fire predicate: armed, the auditioned ayah's end is known, it
+ *  hasn't already fired for that ayah, and the playhead has reached within
+ *  `guardMs` of — or PAST — its end. The `>=` makes the guard a LOWER bound, so
+ *  an overshoot (a skipped frame) still fires; that is the property the leak bug
+ *  violated by re-measuring against the next ayah after focus had advanced. */
+export function shouldFireShuffle(args: ShuffleFireArgs): boolean {
+    const { armed, ms, focusEndMs, guardMs, firedForCurrentFocus } = args;
+    if (!armed || focusEndMs === null || firedForCurrentFocus) return false;
+    return ms >= focusEndMs - guardMs;
+}
+
+/** The verse to focus for playhead `ms`: the one containing it, else the nearest
+ *  preceding, else the first. Returns its ref, or null when there are no verses. */
+export function verseAt(verses: ShuffleTickVerse[], ms: number): string | null {
+    if (verses.length === 0) return null;
+    let hit: ShuffleTickVerse | null = null;
+    for (const v of verses) {
+        if (ms >= v.startMs && ms < v.endMs) { hit = v; break; }
+        if (v.startMs <= ms) hit = v; // nearest preceding
+    }
+    return (hit ?? verses[0]!).ref;
+}
+
+/** Combined tick decision: fire the shuffle jump if the auditioned ayah ended,
+ *  otherwise report which verse to focus. Firing is resolved BEFORE focus so an
+ *  overshoot past a contiguous seam still measures against the auditioned ayah,
+ *  never the next one. */
+export function resolveShuffleTick(
+    args: ShuffleFireArgs & { verses: ShuffleTickVerse[] },
+): ShuffleTickOutcome {
+    if (shouldFireShuffle(args)) return { kind: 'fire' };
+    return { kind: 'focus', ref: verseAt(args.verses, args.ms) };
+}

--- a/inspector/frontend/src/tabs/timestamps/utils/shuffle-tick.ts
+++ b/inspector/frontend/src/tabs/timestamps/utils/shuffle-tick.ts
@@ -11,6 +11,13 @@
  * just-loaded ayah is short) would re-base the boundary onto the NEXT ayah and
  * leak it in full. Resolving the fire decision first, against the auditioned
  * ayah's captured end, bounds the leak to a single frame.
+ *
+ * A cross-source jump also opens a multi-frame window where the shared player
+ * already points at the NEW chapter (so the playhead time is the new chapter's)
+ * but the verse list still describes the OLD chapter, until its data loads.
+ * `resolveShuffleTick` reports `idle` for that window so the caller freezes both
+ * focus and firing instead of interpreting the new time against stale verses
+ * (which would focus a wrong old verse and double-fire the jump).
  */
 
 export interface ShuffleTickVerse {
@@ -20,6 +27,7 @@ export interface ShuffleTickVerse {
 }
 
 export type ShuffleTickOutcome =
+    | { kind: 'idle' }
     | { kind: 'fire' }
     | { kind: 'focus'; ref: string | null };
 
@@ -62,13 +70,17 @@ export function verseAt(verses: ShuffleTickVerse[], ms: number): string | null {
     return (hit ?? verses[0]!).ref;
 }
 
-/** Combined tick decision: fire the shuffle jump if the auditioned ayah ended,
- *  otherwise report which verse to focus. Firing is resolved BEFORE focus so an
- *  overshoot past a contiguous seam still measures against the auditioned ayah,
- *  never the next one. */
+/** Combined tick decision: hold everything while a chapter is mid-swap, else
+ *  fire the shuffle jump if the auditioned ayah ended, otherwise report which
+ *  verse to focus. The swap check comes first because `verses` and the playhead
+ *  belong to different chapters during the swap window, so neither firing nor
+ *  focusing can be trusted. Firing is resolved BEFORE focus so an overshoot past
+ *  a contiguous seam still measures against the auditioned ayah, never the next
+ *  one. */
 export function resolveShuffleTick(
-    args: ShuffleFireArgs & { verses: ShuffleTickVerse[] },
+    args: ShuffleFireArgs & { verses: ShuffleTickVerse[]; swapInFlight: boolean },
 ): ShuffleTickOutcome {
+    if (args.swapInFlight) return { kind: 'idle' };
     if (shouldFireShuffle(args)) return { kind: 'fire' };
     return { kind: 'focus', ref: verseAt(args.verses, args.ms) };
 }


### PR DESCRIPTION
## Problem

In the Timestamps tab, **Random Aya** (auto-random shuffle) is supposed to play a verse to its end and then jump to a new random verse. It worked for most verses, but **short verses consistently leaked** — playback continued into the *next* contiguous verse (half or the full verse) before the random jump fired.

## Root cause

The per-frame rAF `tick()` advanced the **visual focus** to the verse containing the playhead *before* checking the ayah-end shuffle boundary, and the boundary was measured off that focus verse. Because continuously-recited verses are contiguous (`X.end == X+1.start`), the instant the playhead crossed the seam the focus flipped to the next verse, so the boundary check then measured against *its* end → the jump didn't fire until the end of the following verse → the whole next verse leaked.

It correlates with **short verses** because jumping does heavy synchronous main-thread work (chapter shard load, peaks decode, display DOM rebuild) that starves `requestAnimationFrame` for a few hundred ms right after each jump — and a short verse ends *during* that starvation, so the 40 ms fire window gets skipped. Not a pre-warming or bucket issue; a frame-timing race that read the boundary off the wrong verse.

## Changes (3 commits)

1. **`fix(ts-fe): random-ayah end fires before focus drift`** — the tick now resolves fire-vs-focus together, *before* drifting focus, measuring against the auditioned verse's captured end. Even a skipped frame still fires against the correct verse → leak bounded to one frame instead of a whole verse. Extracted the decision into a pure, tested module `utils/shuffle-tick.ts`.

2. **`fix(ts-fe): freeze tick during cross-source shuffle swap`** — fixes a related latent double-fire / wrong-verse-focus flash (flagged in review): during a cross-source jump the shared player swaps to the new chapter synchronously while `chapterVerses`/`focusRef` still describe the old chapter until `syncChapter` lands. `tick()` and the media-clock backstop now no-op while `loadedChapterKey` trails `playerContext`, so the new playhead time isn't read against stale verses.

3. **`chore(ts-fe): drop dead pre-dashPort playback stores`** — removed the dead pre-shared-`dashPort` cohort from `timestamps/stores/playback.ts` (`autoAdvancing`, the `@deprecated` `tsPort`/`tsPortReady`/`tsAudioElement`/`tsVbrChapters`, the unconsumed `currentTime`, and `autoMode`/`TsAutoMode` + its sole vestigial `.set(null)`), leaving only the live `exitLoop`/`loopTarget`/`TsLoopTarget` re-export shim.

## Verification

- `npm run check` — 0 errors / 0 warnings
- `npm run lint` — clean
- `npm run test` — 82 files / 652 tests pass (incl. 14 new cases in `shuffle-tick.test.ts`, covering the overshoot-still-fires contract and the cross-source swap window)

Not run: a live browser smoke (needs the dev stack + bucket audio, which isn't available in this worktree). Logic-level verification is complete; happy to smoke it end-to-end if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
