### PR TITLE
feat(segs-fe): wasl picker — arrow/Tab cycle, Enter commits child

### DIFF
--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -93,3 +93,7 @@ Row-owned edit actions (A/S/E/G + delete) and card-owned ones (L ignore, F auto-
 5. `npm run check` / `lint` / `test`. Store behaviour is covered by `tabs/segments/shortcuts/__tests__/store.test.ts`.
 
 Structural keys (Enter / Escape / Tab / in-edit arrows / Ctrl+S / R) are intentionally `rebindable: false` so confirm/cancel/stepper stay stable.
+
+## Self-contained widgets (outside the dispatcher)
+
+`WaslBoundary.svelte` — the WASL/WAQF picker that pauses a cross-verse split chain after each child's ref-edit — owns its own keyboard, not the dispatcher. While the boundary is the paused step (auto-focused), `←`/`→` highlight WASL/WAQF positionally, `Tab` toggles, and `Enter` commits the highlighted choice and advances the chain to the next child. It `stopPropagation`s those keys so the global handler doesn't also seek / move focus; everything else (Space preview, …) falls through to `handleSegmentsKey`.

--- a/inspector/frontend/src/tabs/segments/components/validation/WaslBoundary.svelte
+++ b/inspector/frontend/src/tabs/segments/components/validation/WaslBoundary.svelte
@@ -27,6 +27,13 @@
      * After commit, the picker clears its UID from pendingWaslConfirm,
      * unhooks focus, and calls resumePendingChain() so the post-split
      * chain advances to the next piece's ref-edit.
+     *
+     * Keyboard (while this boundary is the paused chain step): ← highlights
+     * WASL, → highlights WAQF (positional), Tab toggles between them, and
+     * Enter commits the highlighted choice — advancing the chain to the next
+     * child's ref-edit. Handled locally (the picker auto-focuses a button)
+     * and stopPropagation'd so the global Segments dispatcher doesn't also
+     * seek / cycle focus away on those keys. Space + other keys fall through.
      */
 
     import { tick } from 'svelte';
@@ -51,6 +58,12 @@
     export let rightSeg: Segment;
 
     let waslBtnEl: HTMLButtonElement | undefined;
+    let waqfBtnEl: HTMLButtonElement | undefined;
+
+    /** Transient keyboard highlight while this boundary is the paused chain
+     *  step. ←/→ pick positionally (WASL · WAQF), Tab toggles, Enter commits.
+     *  Null whenever this picker isn't the active step. */
+    let highlighted: 'wasl' | 'waqf' | null = null;
 
     $: leftUid = leftSeg.segment_uid ?? '';
     $: sameChapter =
@@ -66,8 +79,42 @@
     // appears; otherwise the user sees the ring mid-scroll and may miss it.
     $: if (leftUid && $focusWaslBoundary === leftUid && waslBtnEl) {
         const el = waslBtnEl;
+        highlighted = 'wasl';
         el.scrollIntoView({ block: 'center', behavior: 'smooth' });
         void tick().then(() => el.focus());
+    }
+
+    /** Move the keyboard highlight to `side` and pull DOM focus with it so the
+     *  focus ring tracks the staged choice. */
+    function setHighlight(side: 'wasl' | 'waqf', e: KeyboardEvent): void {
+        e.preventDefault();
+        e.stopPropagation();
+        highlighted = side;
+        (side === 'wasl' ? waslBtnEl : waqfBtnEl)?.focus();
+    }
+
+    /** Keyboard nav for the paused chain step: ← / → highlight WASL / WAQF
+     *  positionally, Tab toggles, Enter commits the highlighted choice and
+     *  advances the chain. Only intercepts while this boundary is pending —
+     *  other keys (Space preview, …) bubble to the global Segments dispatcher. */
+    function onPickerKeydown(e: KeyboardEvent): void {
+        if (!isPending) return;
+        switch (e.key) {
+            case 'ArrowLeft':
+                setHighlight('wasl', e);
+                break;
+            case 'ArrowRight':
+                setHighlight('waqf', e);
+                break;
+            case 'Tab':
+                setHighlight(highlighted === 'wasl' ? 'waqf' : 'wasl', e);
+                break;
+            case 'Enter':
+                e.preventDefault();
+                e.stopPropagation();
+                commit(highlighted !== 'waqf');
+                break;
+        }
     }
 
     function commit(value: boolean): void {
@@ -92,6 +139,7 @@
         } catch (err) {
             console.warn('WaslBoundary: commit failed:', err);
         } finally {
+            highlighted = null;
             clearWaslPending(leftUid);
             focusWaslBoundary.set(null);
             // Re-enter the chain handoff. If a pending wasl gate was the
@@ -130,19 +178,24 @@
                 type="button"
                 class="choice"
                 class:active={!isPending && isWasl}
+                class:highlighted={isPending && highlighted === 'wasl'}
                 aria-pressed={!isPending && isWasl}
                 title="Wasl — continuous recitation across this boundary"
                 use:editGate
+                on:keydown={onPickerKeydown}
                 on:click={() => commit(true)}
             >WASL</button>
             <span class="sep" aria-hidden="true">·</span>
             <button
+                bind:this={waqfBtnEl}
                 type="button"
                 class="choice"
                 class:active={!isPending && !isWasl}
+                class:highlighted={isPending && highlighted === 'waqf'}
                 aria-pressed={!isPending && !isWasl}
                 title="Waqf — the reciter stopped at this boundary"
                 use:editGate
+                on:keydown={onPickerKeydown}
                 on:click={() => commit(false)}
             >WAQF</button>
         </span>
@@ -210,6 +263,12 @@
     }
     .choice.active:hover {
         color: var(--accent-strong);
+    }
+    /* Staged keyboard choice during the paused chain step — accent it so the
+       pending selection reads clearly before Enter commits it. */
+    .choice.highlighted {
+        color: var(--accent);
+        font-weight: 600;
     }
     .choice:focus-visible {
         outline: 2px solid var(--accent);

--- a/inspector/frontend/svelte.config.js
+++ b/inspector/frontend/svelte.config.js
@@ -2,4 +2,11 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 export default {
     preprocess: vitePreprocess(),
+    compilerOptions: {
+        // This is an internal editor tool, not a public a11y-audited site.
+        // Drop the compiler's a11y hints so they don't surface as svelte-check
+        // warnings or clutter the dev console. Honoured by both svelte-check
+        // and the vite/build compiler.
+        warningFilter: (w) => !w.code.startsWith('a11y'),
+    },
 };


### PR DESCRIPTION
The cross-verse split's WASL/WAQF boundary picker now owns its keys while paused on the chain step — arrows highlight positionally, Tab toggles, Enter commits and advances to the next child — and a11y compiler warnings are dropped from svelte-check via svelte.config warningFilter.